### PR TITLE
release: v2.0.2 — pyo3 security patch (RUSTSEC-2026-0176/0177)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-15, windows-latest] # macos pinned: macos-latest (Xcode 26.5) breaks clang_rt.osx linking
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-15, windows-latest] # macos pinned: macos-latest (Xcode 26.5) breaks clang_rt.osx linking
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -31,6 +31,15 @@ jobs:
           components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@v2
+
+      - name: Select a pre-26 Xcode (Xcode 26.5 clang_rt.osx layout breaks rustc linking)
+        if: runner.os == 'macOS'
+        run: |
+          ls -d /Applications/Xcode_*.app 2>/dev/null || true
+          for v in 16.4 16.3 16.2 16.1 16.0 15.4 15.2; do
+            if [ -d "/Applications/Xcode_$v.app" ]; then sudo xcode-select -s "/Applications/Xcode_$v.app"; break; fi
+          done
+          echo "Selected Xcode: $(xcode-select -p)"
 
       - name: Format check
         run: cargo fmt --all --check

--- a/.github/workflows/crates-release.yml
+++ b/.github/workflows/crates-release.yml
@@ -50,14 +50,10 @@ jobs:
       # Publish in dependency order with wait between each.
       # "|| true" allows the step to pass if the version already exists
       # (e.g., when republishing after a manual publish).
+      # NOTE: pulsehive-runtime dev-depends on pulsehive-openai, so openai must
+      # be indexed BEFORE runtime is published, or runtime's verify build fails.
       - name: Publish pulsehive-core
         run: cargo publish -p pulsehive-core || true
-
-      - name: Wait for index propagation
-        run: sleep 30
-
-      - name: Publish pulsehive-runtime
-        run: cargo publish -p pulsehive-runtime || true
 
       - name: Wait for index propagation
         run: sleep 30
@@ -67,6 +63,12 @@ jobs:
 
       - name: Publish pulsehive-anthropic
         run: cargo publish -p pulsehive-anthropic || true
+
+      - name: Wait for index propagation
+        run: sleep 30
+
+      - name: Publish pulsehive-runtime
+        run: cargo publish -p pulsehive-runtime || true
 
       - name: Wait for index propagation
         run: sleep 30

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-15 # pinned off macos-latest (Xcode 26.5 clang_rt link bug)
+          - os: macos-latest
             target: aarch64-apple-darwin
             platform: macOS-arm64
           - os: ubuntu-latest
@@ -48,6 +48,15 @@ jobs:
       - name: Install npm deps
         working-directory: pulsehive-js
         run: npm install
+
+      - name: Select a pre-26 Xcode (Xcode 26.5 clang_rt.osx layout breaks rustc linking)
+        if: runner.os == 'macOS'
+        run: |
+          ls -d /Applications/Xcode_*.app 2>/dev/null || true
+          for v in 16.4 16.3 16.2 16.1 16.0 15.4 15.2; do
+            if [ -d "/Applications/Xcode_$v.app" ]; then sudo xcode-select -s "/Applications/Xcode_$v.app"; break; fi
+          done
+          echo "Selected Xcode: $(xcode-select -p)"
 
       - name: Build native addon
         working-directory: pulsehive-js

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest
+          - os: macos-15 # pinned off macos-latest (Xcode 26.5 clang_rt link bug)
             target: aarch64-apple-darwin
             platform: macOS-arm64
           - os: ubuntu-latest

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-15 # pinned off macos-latest (Xcode 26.5 clang_rt link bug)
+          - os: macos-latest
             target: aarch64-apple-darwin
             platform: macOS-arm64
           - os: ubuntu-latest
@@ -33,6 +33,15 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+
+      - name: Select a pre-26 Xcode (Xcode 26.5 clang_rt.osx layout breaks rustc linking)
+        if: runner.os == 'macOS'
+        run: |
+          ls -d /Applications/Xcode_*.app 2>/dev/null || true
+          for v in 16.4 16.3 16.2 16.1 16.0 15.4 15.2; do
+            if [ -d "/Applications/Xcode_$v.app" ]; then sudo xcode-select -s "/Applications/Xcode_$v.app"; break; fi
+          done
+          echo "Selected Xcode: $(xcode-select -p)"
 
       - name: Build wheel
         uses: PyO3/maturin-action@v1

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -74,26 +74,23 @@ jobs:
           name: sdist
           path: dist/*.tar.gz
 
-  # TODO: Uncomment when PyPI account is configured
-  # publish:
-  #   name: Publish to PyPI
-  #   needs: [build-wheels, build-sdist]
-  #   runs-on: ubuntu-latest
-  #   # Only publish on tag push (not workflow_dispatch)
-  #   if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-  #   environment: pypi
-  #   permissions:
-  #     id-token: write  # For trusted publishing
-  #   steps:
-  #     - name: Download all artifacts
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         path: dist
-  #         merge-multiple: true
-  #
-  #     - name: Publish to PyPI
-  #       uses: pypa/gh-action-pypi-publish@release/v1
-  #       with:
-  #         # Uses trusted publishing (OIDC) — no API token needed
-  #         # Configure at: https://pypi.org/manage/project/pulsehive/settings/publishing/
-  #         packages-dir: dist/
+  publish:
+    name: Publish to PyPI
+    needs: [build-wheels, build-sdist]
+    runs-on: ubuntu-latest
+    # Only publish on tag push (not workflow_dispatch)
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    environment: pypi
+    permissions:
+      id-token: write # trusted publishing (OIDC)
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          packages-dir: dist/

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest
+          - os: macos-15 # pinned off macos-latest (Xcode 26.5 clang_rt link bug)
             target: aarch64-apple-darwin
             platform: macOS-arm64
           - os: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to PulseHive will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2026-07-01
+
+### Security
+- **pulsehive-py**: upgrade PyO3 `0.28` -> `0.29`, fixing **RUSTSEC-2026-0176** (out-of-bounds read in `PyList`/`PyTuple` iterators) and **RUSTSEC-2026-0177** (missing `Sync` bound on `PyCFunction::new_closure`). Also upgrades `pyo3-async-runtimes` to `0.29`.
+- Declare a Rust **1.83** MSRV (PyO3 0.29 requirement) across all crates.
+
+### Fixed
+- Correct crate metadata `repository`/`homepage` URLs to `github.com/pulseai-labs/PulseHive` (previously the stale `pulsehive/pulsehive` path).
+
+### Changed
+- Security/CI hardening: `cargo-deny` + `cargo-audit` gates (SHA-pinned actions), read-only workflow `GITHUB_TOKEN`, Dependabot config, `SECURITY.md` / `LICENSING.md` / `PUBLIC_BOUNDARY.md`, and a hardened `.gitignore`.
+
 ## [2.0.0] - 2026-03-26
 
 ### Breaking Changes — PulseVision-Ready Events

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ napi-derive = "3"
 napi-build = "1"
 
 # Internal crate references (path + version for crates.io publishing)
-pulsehive-core = { path = "pulsehive-core", version = "2.0.1" }
-pulsehive-runtime = { path = "pulsehive-runtime", version = "2.0.1" }
-pulsehive-openai = { path = "pulsehive-openai", version = "2.0.1" }
-pulsehive-anthropic = { path = "pulsehive-anthropic", version = "2.0.1" }
+pulsehive-core = { path = "pulsehive-core", version = "2.0.2" }
+pulsehive-runtime = { path = "pulsehive-runtime", version = "2.0.2" }
+pulsehive-openai = { path = "pulsehive-openai", version = "2.0.2" }
+pulsehive-anthropic = { path = "pulsehive-anthropic", version = "2.0.2" }

--- a/EXECUTIVE-SUMMARY.md
+++ b/EXECUTIVE-SUMMARY.md
@@ -20,7 +20,7 @@ No sixth primitive without a demonstrated, repo-backed use case. Enums over stri
 
 ## Status & direction
 
-- **Shipped (v2.0.1, AGPL-3.0, crates.io):** five primitives, agentic loop, workflow agents, intelligence layer, Anthropic + OpenAI-compatible providers, `HiveEvent` stream + `EventExporter`, PulseDB integration, Python (PyO3) + TypeScript (napi-rs) bindings.
+- **Shipped (v2.0.2, AGPL-3.0, crates.io):** five primitives, agentic loop, workflow agents, intelligence layer, Anthropic + OpenAI-compatible providers, `HiveEvent` stream + `EventExporter`, PulseDB integration, Python (PyO3) + TypeScript (napi-rs) bindings.
 - **Next (v2.1.0 — Sprint 1, additive):** streaming tool execution + `ToolProgress` events; cooperative cancellation; subscription-billed subprocess providers (Claude Code + Codex), stateless then stateful. One coordinated `#[non_exhaustive]` migration absorbs the only contract change.
 - **Deferred (v3.0):** breaking work (e.g. `TokenUsage` → tagged `Usage` enum).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,7 +25,7 @@ Please give us a reasonable window to release a fix before any public disclosure
 
 ## Supported versions
 
-PulseHive is on the `2.x` line; the latest published `2.x` release (currently **2.0.1**) on crates.io is supported. Security fixes target the **latest published `2.x` release** — older releases are not patched, so please upgrade.
+PulseHive is on the `2.x` line; the latest published `2.x` release on crates.io is supported. Security fixes target the **latest published `2.x` release** — older releases are not patched, so please upgrade.
 
 | Version | Supported |
 |---------|-----------|

--- a/pulsehive-anthropic/Cargo.toml
+++ b/pulsehive-anthropic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pulsehive-anthropic"
-version = "2.0.1"
+version = "2.0.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/pulsehive-core/Cargo.toml
+++ b/pulsehive-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pulsehive-core"
-version = "2.0.1"
+version = "2.0.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/pulsehive-js/Cargo.toml
+++ b/pulsehive-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pulsehive-js"
-version = "2.0.1"
+version = "2.0.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/pulsehive-js/package.json
+++ b/pulsehive-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsehive/sdk",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "TypeScript/Node.js bindings for PulseHive multi-agent SDK",
   "main": "wrapper.js",
   "types": "wrapper.d.ts",

--- a/pulsehive-openai/Cargo.toml
+++ b/pulsehive-openai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pulsehive-openai"
-version = "2.0.1"
+version = "2.0.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/pulsehive-py/Cargo.toml
+++ b/pulsehive-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pulsehive-py"
-version = "2.0.1"
+version = "2.0.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/pulsehive-py/pyproject.toml
+++ b/pulsehive-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pulsehive"
-version = "0.3.0b1"
+version = "0.3.0b2"
 requires-python = ">=3.9"
 description = "Python bindings for PulseHive — shared consciousness SDK for multi-agent AI systems"
 readme = "README.md"

--- a/pulsehive-runtime/Cargo.toml
+++ b/pulsehive-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pulsehive-runtime"
-version = "2.0.1"
+version = "2.0.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/pulsehive/Cargo.toml
+++ b/pulsehive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pulsehive"
-version = "2.0.1"
+version = "2.0.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
Expedited **2.0.2** security patch — ships the PyO3 0.29 fix (RUSTSEC-2026-0176 / RUSTSEC-2026-0177) that landed in #13 to published artifacts.

### Version bumps
- Rust crates (×7) `2.0.1` → `2.0.2` (+ internal `[workspace.dependencies]` pins)
- **PyPI `pulsehive`** `0.3.0b1` → `0.3.0b2` — the security-critical artifact (pyo3 lives only in `pulsehive-py`)
- npm `@pulsehive/sdk` `2.0.1` → `2.0.2`
- CHANGELOG `[2.0.2]`

### To publish after merge
1. `git checkout main && git pull`
2. `git tag v2.0.2 && git push origin v2.0.2`
3. The tag fires `crates-release`, `python-release`, `npm-release`. Approve the **`crates-io`** deployment environment to release the crates.
4. Confirm `pulsehive 0.3.0b2` on PyPI (the vuln fix) and `2.0.2` on crates.io/npm.

Refs #3 (metadata reaches crates.io on publish).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pulseai-labs/pulsehive/pull/23" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->