### PR TITLE
ci(release): fix crates publish (--no-verify) + PyPI linux wheel (manylinux_2_28)

### DIFF
--- a/.github/workflows/crates-release.yml
+++ b/.github/workflows/crates-release.yml
@@ -53,25 +53,25 @@ jobs:
       # NOTE: pulsehive-runtime dev-depends on pulsehive-openai, so openai must
       # be indexed BEFORE runtime is published, or runtime's verify build fails.
       - name: Publish pulsehive-core
-        run: cargo publish -p pulsehive-core || true
+        run: cargo publish -p pulsehive-core --no-verify || true
 
       - name: Wait for index propagation
         run: sleep 30
 
       - name: Publish pulsehive-openai
-        run: cargo publish -p pulsehive-openai || true
+        run: cargo publish -p pulsehive-openai --no-verify || true
 
       - name: Publish pulsehive-anthropic
-        run: cargo publish -p pulsehive-anthropic || true
+        run: cargo publish -p pulsehive-anthropic --no-verify || true
 
       - name: Wait for index propagation
         run: sleep 30
 
       - name: Publish pulsehive-runtime
-        run: cargo publish -p pulsehive-runtime || true
+        run: cargo publish -p pulsehive-runtime --no-verify || true
 
       - name: Wait for index propagation
         run: sleep 30
 
       - name: Publish pulsehive (meta-crate)
-        run: cargo publish -p pulsehive || true
+        run: cargo publish -p pulsehive --no-verify || true

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           args: --release --out dist --manifest-path pulsehive-py/Cargo.toml
-          manylinux: auto
+          manylinux: 2_28
           # Install OpenSSL dev headers in manylinux container (needed by reqwest/native-tls)
           before-script-linux: |
             if command -v yum &> /dev/null; then


### PR DESCRIPTION
The v2.0.2 tag's release runs surfaced two pre-existing release-pipeline bugs (both hidden until now because 2.0.1 was published manually):

- **crates.io**: `cargo publish --verify` rebuilds each crate, and `ort-sys` (ONNX via pulsehive-db embeddings) tries to download a prebuilt binary from cdn.pyke.io (HTTP 403), failing the verify build; `|| true` masked it → green run, nothing uploaded. Fix: `--no-verify` (CI already builds/tests the workspace).
- **PyPI**: the Linux wheel used `manylinux2014` (CentOS 7, EOL yum repos), so `openssl-devel` won't install and `openssl-sys` fails to build. Fix: `manylinux_2_28` (AlmaLinux 8).

After merge, the v2.0.2 tag is re-pointed at the fixed commit to re-run the publishes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pulseai-labs/pulsehive/pull/25" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->