### PR TITLE
chore: close sprint-1.1 at VS-1.1.1 (1/4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ id_ed25519
 !.env.example
 *.secret
 credentials.json
+
+# scaffold-dev pr_hierarchical work-item worktrees live here; never commit them
+.worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to PulseHive will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - Unreleased
+
+### Added
+- **Streaming tools** — a new `pulsehive_core::tool::StreamingTool: Tool` trait for long-running tools that report live progress. Tools expose it by overriding `Tool::as_streaming()` to return `Some(self)`; the agent loop then calls `StreamingTool::execute_streaming(params, context, progress_tx)` and forwards each pushed event.
+- **`pulsehive_core::tool::ToolProgress`** enum — the progress payload (`Started` / `Progress { fraction, message }` / `PartialResult` / `Log` / `Completed { duration_ms }`). The `Started` / `Completed` bookends are emitted by the agent loop; tool bodies push the intermediate variants.
+- **`HiveEvent::ToolProgress { agent_id, tool_name, progress }`** — the agent loop forwards each `ToolProgress` from a streaming tool as this event on the `HiveMind::deploy()` stream, so consumers see live progress instead of a frozen wait. Delivery on `deploy()` is **best-effort** (a lossy broadcast that drops events for lagging subscribers); the ordered `Started → … → Completed` envelope is emitted in order by the loop but preserved by **neither** transport for consumers (the `deploy()` broadcast drops on lag; a configured `EventExporter` receives each event via an independent fire-and-forget task), so consumers should not treat `Completed` as a guaranteed terminal marker.
+- New runnable, hermetic example `pulsehive-runtime/examples/streaming_tool.rs` (no API key) and a "Streaming Tools" section in `docs/05-API-Spec.md`.
+
+### Changed
+- **BREAKING: `HiveEvent` is now `#[non_exhaustive]`.** New event variants (such as `ToolProgress`) can be added in a minor release without a major bump. External code that matches on `HiveEvent` exhaustively must add a `_ => {}` catch-all arm, or it will fail to compile.
+
 ## [2.0.2] - 2026-07-01
 
 ### Security

--- a/docs/05-API-Spec.md
+++ b/docs/05-API-Spec.md
@@ -267,6 +267,122 @@ pub trait SubstrateProvider: Send + Sync {
 
 Products do not implement this trait directly. They use `PulseDBSubstrate` (the production implementation) or a mock for testing.
 
+### 2.7 StreamingTool (Streaming Tools)
+
+*Since v2.1.0.* An opt-in extension for **streaming tools** — long-running tools
+that report live progress instead of a frozen wait. A tool that implements only
+`Tool` is still fully supported (the agent loop wraps it so it emits `Started` →
+`Completed` with no intermediate events); implement `StreamingTool` when a tool
+is long-running and the consumer wants progress bars, partial results, or a log
+stream.
+
+`StreamingTool: Tool`, so every streaming tool is also a regular `Tool` and can
+be stored as `Arc<dyn Tool>` and registered the same way. A tool exposes its
+streaming path by overriding `Tool::as_streaming()` to return `Some(self)`; the
+agent loop calls `execute_streaming()` on that path and forwards each pushed
+`ToolProgress` as a `HiveEvent::ToolProgress`.
+
+```rust
+/// A progress event pushed by a streaming tool during execution.
+///
+/// Serializes to tagged JSON: `{"kind": "progress", "fraction": 0.5, ...}`.
+pub enum ToolProgress {
+    /// Emitted automatically by the loop before the tool body runs.
+    Started { estimated_duration_ms: Option<u64> },
+    /// Fractional progress in `0.0..=1.0`, with an optional label.
+    Progress { fraction: f32, message: Option<String> },
+    /// A partial result available before the tool completes.
+    PartialResult { payload: serde_json::Value },
+    /// A log line surfaced to the consumer's session timeline.
+    Log { level: LogLevel, message: String },
+    /// Emitted automatically by the loop after the tool body returns.
+    Completed { duration_ms: u64 },
+}
+
+#[async_trait]
+pub trait StreamingTool: Tool {
+    /// Execute the tool, pushing `ToolProgress` over `progress_tx` as work
+    /// proceeds. Implementations SHOULD send `Progress` / `PartialResult` /
+    /// `Log`; they MUST NOT send `Started` / `Completed` (the loop emits those
+    /// bookends). If the receiver is dropped, `send().await` errors — treat it
+    /// as a soft signal, keep computing, and return the result anyway.
+    async fn execute_streaming(
+        &self,
+        params: serde_json::Value,
+        context: &ToolContext,
+        progress_tx: tokio::sync::mpsc::Sender<ToolProgress>,
+    ) -> Result<ToolResult, PulseHiveError>;
+}
+```
+
+**Observing progress.** The agent loop forwards each `ToolProgress` as a
+[`HiveEvent::ToolProgress`](#42-hiveevent) `{ agent_id, tool_name, progress }` on
+the `HiveMind::deploy()` stream. Because the event bus is a lossy broadcast,
+drain the stream **concurrently** with the run (not collect-after):
+
+> **Delivery is best-effort on `deploy()`.** The loop emits the envelope in order
+> (`Started` → intermediate progress → `Completed`), but `deploy()` returns a
+> `tokio::broadcast` receiver that **drops the oldest events when a subscriber
+> lags**. A slow consumer can therefore miss intermediate events **or even
+> `Started`/`Completed`** — so do **not** treat `Completed` as a guaranteed
+> terminal marker on this stream (e.g. don't hang a progress bar waiting for it).
+> The loop emits the envelope in order, but **neither** transport preserves that order
+> for consumers: `deploy()`'s broadcast drops on lag, and a configured
+> [`EventExporter`] receives each event via an **independent fire-and-forget task**
+> (`EventEmitter::emit` spawns per event), so exports can also arrive out of order.
+> Treat progress as best-effort observability on both paths — not a reliable control
+> signal. If you need a strictly-ordered, guaranteed-terminal feed, serialize it
+> yourself downstream (key on `agent_id`/`tool_name`, order by `timestamp_ms`).
+
+```rust
+struct ProgressStreamTool;
+
+#[async_trait]
+impl Tool for ProgressStreamTool {
+    fn name(&self) -> &str { "progress_stream" }
+    fn description(&self) -> &str { "Reports live fractional progress" }
+    fn parameters(&self) -> serde_json::Value { json!({ "type": "object" }) }
+    async fn execute(&self, _p: serde_json::Value, _c: &ToolContext) -> Result<ToolResult> {
+        Ok(ToolResult::text("done")) // non-streaming fallback
+    }
+    fn as_streaming(&self) -> Option<&dyn StreamingTool> { Some(self) }
+}
+
+#[async_trait]
+impl StreamingTool for ProgressStreamTool {
+    async fn execute_streaming(
+        &self,
+        _params: serde_json::Value,
+        _ctx: &ToolContext,
+        progress_tx: mpsc::Sender<ToolProgress>,
+    ) -> Result<ToolResult> {
+        for step in 1..=5 {
+            tokio::time::sleep(Duration::from_millis(800)).await;
+            let _ = progress_tx.send(ToolProgress::Progress {
+                fraction: step as f32 / 5.0,
+                message: Some(format!("step {step}/5")),
+            }).await;
+        }
+        Ok(ToolResult::text("stream complete"))
+    }
+}
+
+// Consumer side — drain deploy()'s stream concurrently with the run.
+let mut stream = hive.deploy(vec![agent], vec![task]).await?;
+while let Some(event) = stream.next().await {
+    match event {
+        HiveEvent::ToolProgress { tool_name, progress, .. } => {
+            println!("[{tool_name}] {progress:?}");
+        }
+        HiveEvent::AgentCompleted { .. } => break,
+        _ => {} // HiveEvent is #[non_exhaustive] (v2.1.0)
+    }
+}
+```
+
+A complete, runnable, hermetic version (no API key) lives at
+`pulsehive-runtime/examples/streaming_tool.rs`.
+
 ---
 
 ## 3. Public Structs
@@ -554,7 +670,12 @@ pub enum AgentKind {
 
 ### 4.2 HiveEvent
 
+As of **v2.1.0**, `HiveEvent` is `#[non_exhaustive]` — new variants can be added
+in a minor release, so external code that matches on it exhaustively **must**
+include a `_ => {}` catch-all arm.
+
 ```rust
+#[non_exhaustive] // v2.1.0 — external exhaustive matches need a `_ => {}` arm
 pub enum HiveEvent {
     // Agent lifecycle
     AgentStarted { agent_id: AgentId, name: String, kind: AgentKindTag },
@@ -569,6 +690,10 @@ pub enum HiveEvent {
     ToolCallStarted { agent_id: AgentId, tool_name: String },
     ToolCallCompleted { agent_id: AgentId, tool_name: String, duration_ms: u64 },
     ToolApprovalRequested { agent_id: AgentId, tool_name: String, action: PendingAction },
+
+    // Streaming tool progress (v2.1.0) — one per `ToolProgress` pushed by a
+    // `StreamingTool`, bracketed by loop-generated Started/Completed bookends.
+    ToolProgress { agent_id: AgentId, tool_name: String, progress: ToolProgress },
 
     // Substrate operations
     ExperienceRecorded { experience_id: ExperienceId, agent_id: AgentId },

--- a/pulsehive-core/Cargo.toml
+++ b/pulsehive-core/Cargo.toml
@@ -25,3 +25,4 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
+tempfile = { workspace = true }

--- a/pulsehive-core/src/event.rs
+++ b/pulsehive-core/src/event.rs
@@ -40,6 +40,7 @@ pub fn now_ms() -> u64 {
 /// which requires cloneable values.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum HiveEvent {
     // ── Agent lifecycle ──────────────────────────────────────────────
     /// An agent has started execution.
@@ -167,6 +168,23 @@ pub enum HiveEvent {
         collective_id: pulsedb::CollectiveId,
         /// The type of change: "Created", "Updated", "Archived", or "Deleted".
         event_type: String,
+    },
+
+    // ── Streaming tool progress ──────────────────────────────────────
+    /// A streaming tool emitted a progress event during execution.
+    ///
+    /// Carries a [`ToolProgress`](crate::tool::ToolProgress) payload
+    /// (`Started` / `Progress` / `PartialResult` / `Log` / `Completed`). The
+    /// agent loop (v2.1.0) forwards each `ToolProgress` pushed by a
+    /// [`StreamingTool`](crate::tool::StreamingTool) as one of these events.
+    ///
+    /// Serializes with the outer tag `"type":"tool_progress"`; the nested
+    /// `progress` retains its own `"kind"` tag.
+    ToolProgress {
+        timestamp_ms: u64,
+        agent_id: String,
+        tool_name: String,
+        progress: crate::tool::ToolProgress,
     },
 }
 
@@ -296,6 +314,34 @@ mod tests {
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("\"params\""));
         assert!(json.contains("\"tool_call_started\""));
+    }
+
+    #[test]
+    fn test_hive_event_serialize_tool_progress() {
+        let event = HiveEvent::ToolProgress {
+            timestamp_ms: 1711500000000,
+            agent_id: "agent-1".into(),
+            tool_name: "backtest".into(),
+            progress: crate::tool::ToolProgress::Progress {
+                fraction: 0.5,
+                message: Some("halfway".into()),
+            },
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        // Outer HiveEvent tag.
+        assert!(json.contains("\"type\":\"tool_progress\""));
+        // Nested ToolProgress keeps its own `kind` tag.
+        assert!(json.contains("\"kind\":\"progress\""));
+
+        // Roundtrip preserves the nested variant.
+        let deserialized: HiveEvent = serde_json::from_str(&json).unwrap();
+        assert!(matches!(
+            deserialized,
+            HiveEvent::ToolProgress {
+                progress: crate::tool::ToolProgress::Progress { .. },
+                ..
+            }
+        ));
     }
 
     #[tokio::test]
@@ -458,9 +504,18 @@ mod tests {
                 collective_id: pulsedb::CollectiveId::new(),
                 event_type: "Created".into(),
             },
+            HiveEvent::ToolProgress {
+                timestamp_ms: 0,
+                agent_id: "a".into(),
+                tool_name: "search".into(),
+                progress: crate::tool::ToolProgress::Progress {
+                    fraction: 0.5,
+                    message: Some("halfway".into()),
+                },
+            },
         ];
         let _cloned: Vec<HiveEvent> = events.to_vec();
-        assert_eq!(events.len(), 14);
+        assert_eq!(events.len(), 15);
     }
 
     #[test]

--- a/pulsehive-core/src/lib.rs
+++ b/pulsehive-core/src/lib.rs
@@ -28,7 +28,7 @@ pub mod prelude {
     pub use crate::embedding::EmbeddingProvider;
     pub use crate::export::EventExporter;
     pub use crate::llm::LlmProvider;
-    pub use crate::tool::Tool;
+    pub use crate::tool::{StreamingTool, Tool};
 
     // ── Agent types ──────────────────────────────────────────────────
     pub use crate::agent::{
@@ -57,7 +57,7 @@ pub mod prelude {
     };
 
     // ── Tool types ───────────────────────────────────────────────────
-    pub use crate::tool::{ToolContext, ToolResult};
+    pub use crate::tool::{LogLevel, ToolContext, ToolProgress, ToolResult};
 
     // ── PulseDB re-exports ───────────────────────────────────────────
     pub use pulsedb::{

--- a/pulsehive-core/src/tool.rs
+++ b/pulsehive-core/src/tool.rs
@@ -25,7 +25,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use pulsedb::{CollectiveId, SubstrateProvider};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use tokio::sync::mpsc;
 
 use crate::error::Result;
 use crate::event::EventEmitter;
@@ -57,6 +59,17 @@ pub trait Tool: Send + Sync {
     /// before executing. Default: `false`.
     fn requires_approval(&self) -> bool {
         false
+    }
+
+    /// If this tool supports streaming execution, return `Some(self)` as a
+    /// [`StreamingTool`]; otherwise `None`.
+    ///
+    /// This is an object-safe capability probe — no `Any`, no `unsafe`, no second
+    /// registry. Non-streaming tools use the `None` default unchanged; a streaming
+    /// tool overrides this single method to return `Some(self)`. The agent loop
+    /// (v2.1.0) dispatches on this to decide whether to open a progress channel.
+    fn as_streaming(&self) -> Option<&dyn StreamingTool> {
+        None
     }
 }
 
@@ -110,6 +123,101 @@ impl ToolResult {
             Self::Error(s) => format!("Error: {s}"),
         }
     }
+}
+
+/// Severity level for a streaming tool [`ToolProgress::Log`] line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LogLevel {
+    /// Fine-grained diagnostic detail.
+    Debug,
+    /// Normal informational progress.
+    Info,
+    /// A recoverable concern worth surfacing.
+    Warn,
+    /// A failure the consumer should see.
+    Error,
+}
+
+/// A progress event emitted by a streaming tool during execution.
+///
+/// Tools implementing [`StreamingTool`] push these over an [`mpsc::Sender`]. The
+/// agent loop (v2.1.0) forwards each one as a `HiveEvent::ToolProgress`. The
+/// `Started` / `Completed` bookends are emitted by the loop, not by tool bodies.
+///
+/// Serializes to tagged JSON: `{"kind": "progress", "fraction": 0.5, ...}`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ToolProgress {
+    /// Tool has begun. Emitted automatically by the loop before the tool body runs.
+    Started {
+        /// Optional caller estimate of total duration, for UI ETA rendering.
+        estimated_duration_ms: Option<u64>,
+    },
+    /// Fractional progress in `0.0..=1.0`, with an optional human-readable label.
+    Progress {
+        /// Completion fraction in `0.0..=1.0`.
+        fraction: f32,
+        /// Optional human-readable status label.
+        message: Option<String>,
+    },
+    /// A partial result available before the tool completes (e.g. the first 100
+    /// trades of a backtest, one sweep combination's score).
+    PartialResult {
+        /// Untyped JSON so partial results from all tools aggregate on one stream.
+        payload: Value,
+    },
+    /// A log line surfaced to the consumer's session timeline.
+    Log {
+        /// Severity of the log line.
+        level: LogLevel,
+        /// The log message.
+        message: String,
+    },
+    /// Tool finished. Emitted automatically by the loop after the tool body returns.
+    Completed {
+        /// Total execution duration in milliseconds.
+        duration_ms: u64,
+    },
+}
+
+/// Opt-in extension for tools that report progress during execution.
+///
+/// Tools that implement only [`Tool`] are still fully supported: the agent loop
+/// wraps them so they emit `Started` → `Completed` with no intermediate events.
+/// Implement this trait when a tool is long-running and the consumer wants live
+/// feedback (progress bars, partial results, log streams).
+///
+/// `StreamingTool: Tool` — every streaming tool is also a regular [`Tool`], so it
+/// can be stored as `Arc<dyn Tool>` and registered the same way. A streaming tool
+/// exposes itself by overriding [`Tool::as_streaming`] to return `Some(self)`.
+#[async_trait]
+pub trait StreamingTool: Tool {
+    /// Execute the tool, pushing [`ToolProgress`] events as work proceeds.
+    ///
+    /// `progress_tx` is a bounded channel owned by the agent loop. Implementations
+    /// SHOULD send `Progress` / `PartialResult` / `Log` events; they MUST NOT send
+    /// `Started` or `Completed` (the loop emits those as bookends). Returns the
+    /// final [`ToolResult`] after the stream is drained. If the receiver is dropped
+    /// (consumer gone), `progress_tx.send().await` errors — implementations SHOULD
+    /// treat that as a soft signal, keep computing, and return the result anyway.
+    ///
+    /// **Progress is observability, not control.** `progress_tx` is the *internal*
+    /// loop→forwarder channel — NOT the consumer's `HiveMind::deploy()` stream. A
+    /// consumer dropping the `deploy()` stream does **not** cancel this tool or stop
+    /// it computing; cooperative cancellation is a separate mechanism (a future
+    /// release). The channel is bounded, so `send().await` can apply backpressure if
+    /// the loop's forwarder falls behind — treat progress as best-effort telemetry,
+    /// and prefer coalescing high-frequency updates rather than relying on every
+    /// send being delivered. Do NOT retain or clone `progress_tx` beyond this call:
+    /// the loop closes the channel by observing your returned future drop it, and a
+    /// leaked/cloned sender keeps the forwarder alive.
+    async fn execute_streaming(
+        &self,
+        params: Value,
+        context: &ToolContext,
+        progress_tx: mpsc::Sender<ToolProgress>,
+    ) -> Result<ToolResult>;
 }
 
 #[cfg(test)]
@@ -174,5 +282,114 @@ mod tests {
             r#"{"a":1}"#
         );
         assert_eq!(ToolResult::error("oops").to_content(), "Error: oops");
+    }
+
+    // Mock streaming tool that ignores its context and pushes a fixed
+    // Progress(0.5) → PartialResult → Progress(1.0) sequence over the channel.
+    struct MockStreamingTool;
+
+    #[async_trait]
+    impl Tool for MockStreamingTool {
+        fn name(&self) -> &str {
+            "mock_streaming"
+        }
+        fn description(&self) -> &str {
+            "mock streaming tool for tests"
+        }
+        fn parameters(&self) -> Value {
+            serde_json::json!({"type": "object"})
+        }
+        async fn execute(&self, _params: Value, _ctx: &ToolContext) -> Result<ToolResult> {
+            Ok(ToolResult::text("final"))
+        }
+        fn as_streaming(&self) -> Option<&dyn StreamingTool> {
+            Some(self)
+        }
+    }
+
+    #[async_trait]
+    impl StreamingTool for MockStreamingTool {
+        async fn execute_streaming(
+            &self,
+            _params: Value,
+            _context: &ToolContext,
+            progress_tx: mpsc::Sender<ToolProgress>,
+        ) -> Result<ToolResult> {
+            // Dropped receiver is a soft signal: ignore send errors, keep going.
+            let _ = progress_tx
+                .send(ToolProgress::Progress {
+                    fraction: 0.5,
+                    message: None,
+                })
+                .await;
+            let _ = progress_tx
+                .send(ToolProgress::PartialResult {
+                    payload: serde_json::json!({"n": 1}),
+                })
+                .await;
+            let _ = progress_tx
+                .send(ToolProgress::Progress {
+                    fraction: 1.0,
+                    message: Some("done".into()),
+                })
+                .await;
+            Ok(ToolResult::text("final"))
+        }
+    }
+
+    /// Builds a minimal `ToolContext`. The substrate/emitter are never touched by
+    /// the mock tool; a temp `Config::default()` PulseDB avoids the ONNX path.
+    fn test_context() -> ToolContext {
+        let dir = tempfile::tempdir().unwrap();
+        let db =
+            pulsedb::PulseDB::open(dir.path().join("test.db"), pulsedb::Config::default()).unwrap();
+        // Leak the tempdir so its files outlive this context.
+        Box::leak(Box::new(dir));
+        ToolContext {
+            agent_id: "agent-test".into(),
+            collective_id: CollectiveId::new(),
+            substrate: Arc::new(pulsedb::PulseDBSubstrate::from_db(db)),
+            event_emitter: EventEmitter::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn streaming_tool_progress_channel_order() {
+        let ctx = test_context();
+        let tool = MockStreamingTool;
+
+        // Capability probe: a streaming tool exposes itself via `as_streaming`.
+        assert!(tool.as_streaming().is_some());
+
+        // Capacity > number of sends so `execute_streaming` never blocks on a
+        // receiver we only drain after it returns.
+        let (tx, mut rx) = mpsc::channel::<ToolProgress>(8);
+        let result = tool.execute_streaming(Value::Null, &ctx, tx).await.unwrap();
+
+        // Drain the channel; the sender is dropped once `execute_streaming` returns.
+        let mut events = Vec::new();
+        while let Some(p) = rx.recv().await {
+            events.push(p);
+        }
+
+        assert_eq!(events.len(), 3, "expected 3 progress events in order");
+        match &events[0] {
+            ToolProgress::Progress { fraction, message } => {
+                assert!((*fraction - 0.5).abs() < f32::EPSILON);
+                assert!(message.is_none());
+            }
+            other => panic!("event[0] expected Progress(0.5), got {other:?}"),
+        }
+        assert!(matches!(events[1], ToolProgress::PartialResult { .. }));
+        match &events[2] {
+            ToolProgress::Progress { fraction, message } => {
+                assert!((*fraction - 1.0).abs() < f32::EPSILON);
+                assert_eq!(message.as_deref(), Some("done"));
+            }
+            other => panic!("event[2] expected Progress(1.0), got {other:?}"),
+        }
+
+        // `execute_streaming` returns the final `ToolResult`.
+        assert!(matches!(result, ToolResult::Text(s) if s == "final"));
     }
 }

--- a/pulsehive-js/src/events.rs
+++ b/pulsehive-js/src/events.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 
 use pulsehive_core::agent::AgentOutcome;
 use pulsehive_core::event::HiveEvent;
+use pulsehive_core::tool::ToolProgress;
 
 #[cfg(feature = "napi")]
 use napi_derive::napi;
@@ -292,6 +293,38 @@ impl From<HiveEvent> for JsHiveEvent {
                 fields.insert("eventType".into(), EventValue::Str(event_type));
                 ("watch_notification", None)
             }
+            HiveEvent::ToolProgress {
+                timestamp_ms,
+                agent_id,
+                tool_name,
+                progress,
+            } => {
+                fields.insert("timestampMs".into(), EventValue::Num(timestamp_ms));
+                fields.insert("agentId".into(), EventValue::Str(agent_id.clone()));
+                fields.insert("toolName".into(), EventValue::Str(tool_name));
+                // The nested `progress` enum has no scalar map representation, so
+                // emit a `progressKind` discriminator plus the full payload as a
+                // JSON string (audit ⑥ default; the flatten-scalars form is deferred).
+                let progress_kind = match &progress {
+                    ToolProgress::Started { .. } => "started",
+                    ToolProgress::Progress { .. } => "progress",
+                    ToolProgress::PartialResult { .. } => "partial_result",
+                    ToolProgress::Log { .. } => "log",
+                    ToolProgress::Completed { .. } => "completed",
+                };
+                fields.insert(
+                    "progressKind".into(),
+                    EventValue::Str(progress_kind.to_string()),
+                );
+                fields.insert(
+                    "progress".into(),
+                    EventValue::Str(serde_json::to_string(&progress).unwrap_or_default()),
+                );
+                ("tool_progress", Some(agent_id))
+            }
+            // Forward-compat: `HiveEvent` is `#[non_exhaustive]`. Future variants
+            // (VS-1.1.2+) map to an inert `unknown` event instead of failing to build.
+            _ => ("unknown", None),
         };
 
         Self {
@@ -299,5 +332,32 @@ impl From<HiveEvent> for JsHiveEvent {
             agent_id,
             fields,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jshiveevent_tool_progress_maps_event_type() {
+        let event = HiveEvent::ToolProgress {
+            timestamp_ms: 1,
+            agent_id: "a1".into(),
+            tool_name: "backtest".into(),
+            progress: ToolProgress::Progress {
+                fraction: 0.5,
+                message: Some("halfway".into()),
+            },
+        };
+        let js_event = JsHiveEvent::from(event);
+        assert_eq!(js_event.event_type, "tool_progress");
+        assert_eq!(js_event.agent_id.as_deref(), Some("a1"));
+        // Nested payload is serialized as a JSON string + a discriminator field.
+        assert!(js_event.fields.contains_key("progress"));
+        assert!(matches!(
+            js_event.fields.get("progressKind"),
+            Some(EventValue::Str(s)) if s == "progress"
+        ));
     }
 }

--- a/pulsehive-py/src/events.rs
+++ b/pulsehive-py/src/events.rs
@@ -10,6 +10,7 @@ use pyo3::types::PyDict;
 
 use pulsehive_core::agent::AgentOutcome;
 use pulsehive_core::event::HiveEvent;
+use pulsehive_core::tool::ToolProgress;
 
 /// Lifecycle and observability event from the PulseHive runtime.
 ///
@@ -311,6 +312,38 @@ impl From<HiveEvent> for PyHiveEvent {
                 fields.insert("event_type".into(), PyEventValue::Str(event_type));
                 ("watch_notification", None)
             }
+            HiveEvent::ToolProgress {
+                timestamp_ms,
+                agent_id,
+                tool_name,
+                progress,
+            } => {
+                fields.insert("timestamp_ms".into(), PyEventValue::Int(timestamp_ms));
+                fields.insert("agent_id".into(), PyEventValue::Str(agent_id.clone()));
+                fields.insert("tool_name".into(), PyEventValue::Str(tool_name));
+                // The nested `progress` enum has no scalar map representation, so
+                // emit a `progress_kind` discriminator plus the full payload as a
+                // JSON string (audit ⑥ default; the flatten-scalars form is deferred).
+                let progress_kind = match &progress {
+                    ToolProgress::Started { .. } => "started",
+                    ToolProgress::Progress { .. } => "progress",
+                    ToolProgress::PartialResult { .. } => "partial_result",
+                    ToolProgress::Log { .. } => "log",
+                    ToolProgress::Completed { .. } => "completed",
+                };
+                fields.insert(
+                    "progress_kind".into(),
+                    PyEventValue::Str(progress_kind.to_string()),
+                );
+                fields.insert(
+                    "progress".into(),
+                    PyEventValue::Str(serde_json::to_string(&progress).unwrap_or_default()),
+                );
+                ("tool_progress", Some(agent_id))
+            }
+            // Forward-compat: `HiveEvent` is `#[non_exhaustive]`. Future variants
+            // (VS-1.1.2+) map to an inert `unknown` event instead of failing to build.
+            _ => ("unknown", None),
         };
 
         Self {
@@ -325,4 +358,31 @@ impl From<HiveEvent> for PyHiveEvent {
 pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyHiveEvent>()?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pyhiveevent_tool_progress_maps_event_type() {
+        let event = HiveEvent::ToolProgress {
+            timestamp_ms: 1,
+            agent_id: "a1".into(),
+            tool_name: "backtest".into(),
+            progress: ToolProgress::Progress {
+                fraction: 0.5,
+                message: Some("halfway".into()),
+            },
+        };
+        let py_event = PyHiveEvent::from(event);
+        assert_eq!(py_event.event_type, "tool_progress");
+        assert_eq!(py_event.agent_id.as_deref(), Some("a1"));
+        // Nested payload is serialized as a JSON string + a discriminator field.
+        assert!(py_event.fields.contains_key("progress"));
+        assert!(matches!(
+            py_event.fields.get("progress_kind"),
+            Some(PyEventValue::Str(s)) if s == "progress"
+        ));
+    }
 }

--- a/pulsehive-runtime/Cargo.toml
+++ b/pulsehive-runtime/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["science", "asynchronous"]
 async-trait = { workspace = true }
 pulsehive-core = { workspace = true }
 pulsehive-db = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["time"] }
 tracing = { workspace = true }
 futures = { workspace = true }
 futures-core = { workspace = true }

--- a/pulsehive-runtime/examples/streaming_tool.rs
+++ b/pulsehive-runtime/examples/streaming_tool.rs
@@ -1,0 +1,298 @@
+//! PulseHive Streaming Tool Example
+//!
+//! Demonstrates a long-running [`StreamingTool`] that reports **live progress**
+//! through the agent loop instead of a frozen wait. A scripted (in-file) LLM
+//! provider requests the streaming tool once; the tool emits fractional
+//! `ToolProgress::Progress` events roughly once per second for ~5s. The agent
+//! loop (v2.1.0) forwards each one as a `HiveEvent::ToolProgress` and brackets
+//! them with loop-generated `Started` / `Completed` bookends.
+//!
+//! Hermetic: no API key and no network — the scripted provider drives the real
+//! `perceive → think → act → record` loop via `HiveMind::deploy()`. The event
+//! stream is drained **concurrently** with the tool run (the agent executes as a
+//! spawned Tokio task), so a burst of progress isn't lapped by the lossy
+//! broadcast `EventBus`.
+//!
+//! This example is a **self-asserting gate**: it counts the `ToolProgress`
+//! events it observes and exits non-zero unless it sees >= 5 of them ending with
+//! the loop-generated `Completed` bookend. Run with:
+//! ```bash
+//! cargo run -p pulsehive-runtime --example streaming_tool
+//! ```
+
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use futures_core::Stream;
+use serde_json::Value;
+
+use pulsehive_core::agent::{AgentDefinition, AgentKind, LlmAgentConfig};
+use pulsehive_core::error::{PulseHiveError, Result};
+use pulsehive_core::event::HiveEvent;
+use pulsehive_core::lens::Lens;
+use pulsehive_core::llm::{
+    LlmChunk, LlmConfig, LlmProvider, LlmResponse, Message, TokenUsage, ToolCall, ToolDefinition,
+};
+use pulsehive_core::tool::{StreamingTool, Tool, ToolContext, ToolProgress, ToolResult};
+use pulsehive_runtime::hivemind::{HiveMind, Task};
+use tokio::sync::mpsc;
+
+/// Number of `Progress` events the streaming tool emits. `>= 5` satisfies the
+/// slice's `auto:` demo criterion with margin against the lossy broadcast.
+const PROGRESS_STEPS: usize = 6;
+
+/// Delay between progress emissions. `< 1000ms` keeps the rate at `>= 1
+/// Progress` per second across ~5s of simulated work.
+const STEP_MS: u64 = 800;
+
+// ── Scripted LLM ────────────────────────────────────────────────────────
+// Requests the streaming tool once, then returns a final text answer. No API
+// key, no network — same in-file provider pattern as `custom_tool.rs`.
+
+struct ScriptedLlm {
+    responses: Mutex<Vec<LlmResponse>>,
+}
+
+impl ScriptedLlm {
+    fn new(responses: Vec<LlmResponse>) -> Self {
+        Self {
+            responses: Mutex::new(responses),
+        }
+    }
+
+    fn text(content: &str) -> LlmResponse {
+        LlmResponse {
+            content: Some(content.into()),
+            tool_calls: vec![],
+            usage: TokenUsage::default(),
+        }
+    }
+
+    fn tool_call(id: &str, name: &str, args: Value) -> LlmResponse {
+        LlmResponse {
+            content: None,
+            tool_calls: vec![ToolCall {
+                id: id.into(),
+                name: name.into(),
+                arguments: args,
+            }],
+            usage: TokenUsage::default(),
+        }
+    }
+}
+
+#[async_trait]
+impl LlmProvider for ScriptedLlm {
+    async fn chat(
+        &self,
+        _messages: Vec<Message>,
+        _tools: Vec<ToolDefinition>,
+        _config: &LlmConfig,
+    ) -> Result<LlmResponse> {
+        let mut responses = self.responses.lock().unwrap();
+        if responses.is_empty() {
+            Err(PulseHiveError::llm("No more scripted responses"))
+        } else {
+            Ok(responses.remove(0))
+        }
+    }
+
+    async fn chat_stream(
+        &self,
+        _messages: Vec<Message>,
+        _tools: Vec<ToolDefinition>,
+        _config: &LlmConfig,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<LlmChunk>> + Send>>> {
+        Err(PulseHiveError::llm(
+            "LLM token streaming is not used in this example",
+        ))
+    }
+}
+
+// ── Streaming tool ──────────────────────────────────────────────────────
+// Emits a `Progress` event every ~800ms for ~5s. The `Started` / `Completed`
+// bookends are emitted by the agent loop, not here.
+
+struct ProgressStreamTool;
+
+#[async_trait]
+impl Tool for ProgressStreamTool {
+    fn name(&self) -> &str {
+        "progress_stream"
+    }
+
+    fn description(&self) -> &str {
+        "Long-running tool that reports live fractional progress"
+    }
+
+    fn parameters(&self) -> Value {
+        serde_json::json!({ "type": "object" })
+    }
+
+    // Non-streaming fallback (never taken here — `as_streaming` returns `Some`).
+    async fn execute(&self, _params: Value, _ctx: &ToolContext) -> Result<ToolResult> {
+        Ok(ToolResult::text("done (non-streaming fallback)"))
+    }
+
+    fn as_streaming(&self) -> Option<&dyn StreamingTool> {
+        Some(self)
+    }
+}
+
+#[async_trait]
+impl StreamingTool for ProgressStreamTool {
+    async fn execute_streaming(
+        &self,
+        _params: Value,
+        _context: &ToolContext,
+        progress_tx: mpsc::Sender<ToolProgress>,
+    ) -> Result<ToolResult> {
+        for step in 1..=PROGRESS_STEPS {
+            tokio::time::sleep(Duration::from_millis(STEP_MS)).await;
+            // A dropped receiver is a soft signal: ignore send errors and keep
+            // computing, returning the final result regardless.
+            let _ = progress_tx
+                .send(ToolProgress::Progress {
+                    fraction: step as f32 / PROGRESS_STEPS as f32,
+                    message: Some(format!("step {step}/{PROGRESS_STEPS}")),
+                })
+                .await;
+        }
+        Ok(ToolResult::text("stream complete"))
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let hive = HiveMind::builder()
+        .substrate_path(dir.path().join("streaming.db"))
+        .llm_provider(
+            "mock",
+            ScriptedLlm::new(vec![
+                ScriptedLlm::tool_call("call_1", "progress_stream", serde_json::json!({})),
+                ScriptedLlm::text("Streaming tool finished."),
+            ]),
+        )
+        .build()
+        .expect("build HiveMind");
+
+    let agent = AgentDefinition {
+        name: "streamer".into(),
+        kind: AgentKind::Llm(Box::new(LlmAgentConfig {
+            system_prompt: "You run a long streaming tool and report its progress.".into(),
+            tools: vec![Arc::new(ProgressStreamTool)],
+            lens: Lens::default(),
+            llm_config: LlmConfig::new("mock", "demo"),
+            experience_extractor: None,
+            refresh_every_n_tool_calls: None,
+        })),
+    };
+
+    println!("=== Streaming Tool Example ===");
+    println!(
+        "Deploying agent 'streamer' with a streaming tool (emits {PROGRESS_STEPS} progress events \
+         over ~5s)\n"
+    );
+
+    let mut stream = hive
+        .deploy(vec![agent], vec![Task::new("Run the streaming tool")])
+        .await
+        .expect("deploy agents");
+
+    // Drain the event stream CONCURRENTLY with the tool run: `deploy()` spawns
+    // the agent as a Tokio task and returns immediately, so polling the returned
+    // stream observes progress live (not collect-after). Bounded by a timeout so
+    // a regression that never completes can't hang CI.
+    let drain = async {
+        let mut total = 0usize;
+        let mut progress = 0usize;
+        // Track the LAST ToolProgress kind so the gate can require the envelope to
+        // actually *end* with Completed (not merely to have seen a Completed
+        // somewhere). `None` until the first ToolProgress arrives.
+        let mut last_kind: Option<&'static str> = None;
+
+        while let Some(event) = stream.next().await {
+            match event {
+                HiveEvent::ToolProgress {
+                    tool_name,
+                    progress: payload,
+                    ..
+                } => {
+                    total += 1;
+                    match payload {
+                        ToolProgress::Started { .. } => {
+                            last_kind = Some("started");
+                            println!("  [{tool_name}] ToolProgress::Started");
+                        }
+                        ToolProgress::Progress { fraction, message } => {
+                            progress += 1;
+                            last_kind = Some("progress");
+                            let label = message.unwrap_or_default();
+                            println!(
+                                "  [{tool_name}] ToolProgress::Progress {:.0}% {label}",
+                                fraction * 100.0
+                            );
+                        }
+                        ToolProgress::Completed { duration_ms } => {
+                            last_kind = Some("completed");
+                            println!("  [{tool_name}] ToolProgress::Completed ({duration_ms}ms)");
+                        }
+                        other => {
+                            last_kind = Some("other");
+                            println!("  [{tool_name}] {other:?}");
+                        }
+                    }
+                }
+                // `HiveEvent` is `#[non_exhaustive]` (v2.1.0), so an external
+                // exhaustive match needs this catch-all arm.
+                HiveEvent::AgentCompleted { .. } => break,
+                _ => {}
+            }
+        }
+
+        (total, progress, last_kind)
+    };
+
+    let (total, progress, last_kind) =
+        match tokio::time::timeout(Duration::from_secs(60), drain).await {
+            Ok(counts) => counts,
+            Err(_) => {
+                eprintln!("REGRESSION: event drain timed out before AgentCompleted");
+                std::process::exit(1);
+            }
+        };
+
+    println!(
+        "\nObserved {total} ToolProgress events ({progress} Progress), last_kind={last_kind:?}"
+    );
+
+    // Self-assert — this makes `cargo run --example streaming_tool` a real gate.
+    // Assert on the *Progress* count (the user-visible live updates), not the total
+    // (which Started/Completed bookends would pad to 5), and require the envelope to
+    // END with the loop-generated Completed bookend — so a regression to fewer live
+    // updates, or a Completed that isn't terminal, fails loudly.
+    if progress < 5 || last_kind != Some("completed") {
+        eprintln!(
+            "REGRESSION: expected >= 5 live Progress updates ending with Completed, \
+             got total={total} progress={progress} last_kind={last_kind:?}"
+        );
+        std::process::exit(1);
+    }
+
+    println!("SELF-ASSERT PASSED: >= 5 live Progress updates observed, ending with Completed.");
+
+    hive.shutdown();
+
+    // Force exit: PulseDB's ONNX runtime holds background threads that prevent a
+    // clean Tokio runtime shutdown (same known issue as the custom_tool example).
+    // NOTE: because this bypasses destructors, this example gates *event
+    // observation* (the streaming envelope reaching a subscriber), NOT task-lifecycle
+    // correctness — it is not evidence that the forwarder task, exporter, or agent
+    // tasks shut down cleanly. Lifecycle/leak checks belong in the runtime test suite.
+    std::process::exit(0);
+}

--- a/pulsehive-runtime/src/agentic_loop.rs
+++ b/pulsehive-runtime/src/agentic_loop.rs
@@ -7,9 +7,10 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use pulsedb::SubstrateProvider;
+use tokio::sync::mpsc;
 use tracing::Instrument;
 
 use pulsehive_core::agent::{AgentOutcome, ExperienceExtractor, LlmAgentConfig};
@@ -17,7 +18,7 @@ use pulsehive_core::approval::{ApprovalHandler, ApprovalResult, PendingAction};
 use pulsehive_core::event::{EventEmitter, HiveEvent};
 use pulsehive_core::lens::Lens;
 use pulsehive_core::llm::{LlmConfig, LlmProvider, Message, ToolCall, ToolDefinition};
-use pulsehive_core::tool::{Tool, ToolContext, ToolResult};
+use pulsehive_core::tool::{Tool, ToolContext, ToolProgress, ToolResult};
 
 use crate::hivemind::Task;
 
@@ -312,6 +313,18 @@ async fn execute_tool_inner(
         params: params_str,
     });
 
+    // Loop-generated `Started` bookend — emitted for EVERY tool (streaming or
+    // not) right after `ToolCallStarted`, so every tool call produces the
+    // `Started → … → Completed` envelope.
+    event_emitter.emit(HiveEvent::ToolProgress {
+        timestamp_ms: pulsehive_core::event::now_ms(),
+        agent_id: agent_id.to_string(),
+        tool_name: tool_name.to_string(),
+        progress: ToolProgress::Started {
+            estimated_duration_ms: None,
+        },
+    });
+
     let start = Instant::now();
     let context = ToolContext {
         agent_id: agent_id.to_string(),
@@ -320,11 +333,72 @@ async fn execute_tool_inner(
         event_emitter: event_emitter.clone(),
     };
 
-    let result = match tool
-        .execute(params, &context)
-        .instrument(tracing::debug_span!("tool_execute", tool = %tool_name))
-        .await
-    {
+    // Dispatch on the streaming capability probe. Streaming tools get a bounded
+    // progress channel plus a forwarder task that pumps each `ToolProgress` into
+    // the `HiveEvent` stream; non-streaming tools take the existing path verbatim.
+    let exec_result = match tool.as_streaming() {
+        Some(streaming) => {
+            let (tx, mut rx) = mpsc::channel::<ToolProgress>(64);
+
+            // Forwarder: drain the tool's progress channel and re-emit each item
+            // as a `HiveEvent::ToolProgress`. Owns its own emitter clone + labels
+            // so it is `Send + 'static` for `tokio::spawn`.
+            let forwarder_emitter = event_emitter.clone();
+            let forwarder_agent = agent_id.to_string();
+            let forwarder_tool = tool_name.to_string();
+            let mut forwarder = tokio::spawn(async move {
+                while let Some(progress) = rx.recv().await {
+                    forwarder_emitter.emit(HiveEvent::ToolProgress {
+                        timestamp_ms: pulsehive_core::event::now_ms(),
+                        agent_id: forwarder_agent.clone(),
+                        tool_name: forwarder_tool.clone(),
+                        progress,
+                    });
+                }
+            });
+
+            // Run the streaming body. The `tx` we passed is the only sender clone;
+            // it drops when `execute_streaming` returns, closing the channel so the
+            // forwarder observes end-of-stream.
+            let result = streaming
+                .execute_streaming(params, &context, tx)
+                .instrument(tracing::debug_span!("tool_execute", tool = %tool_name))
+                .await;
+
+            // The tool has returned; drain the forwarder so every buffered progress
+            // event is emitted before the `Completed` bookend below. Under the normal
+            // contract (the sole `progress_tx` drops when `execute_streaming` returns)
+            // the channel closes and the forwarder finishes immediately. But
+            // `mpsc::Sender` is `Clone` and tools are third-party code: a tool that
+            // clones/leaks the sender into a background task would keep the channel
+            // open forever, so an unbounded `forwarder.await` here would hang the whole
+            // deployment (no `Completed` / `ToolCallCompleted` / next turn). Bound the
+            // wait: give the forwarder a short grace to drain, then stop it — a
+            // misbehaving tool must not wedge the agent. (Fuller hardening — scoped
+            // sender, backpressure contract, adversarial tests — tracked in the
+            // streaming-tool hardening follow-up.)
+            const FORWARDER_DRAIN_GRACE: Duration = Duration::from_secs(5);
+            if tokio::time::timeout(FORWARDER_DRAIN_GRACE, &mut forwarder)
+                .await
+                .is_err()
+            {
+                tracing::warn!(
+                    tool = %tool_name,
+                    "streaming tool left a progress sender open after returning; \
+                     stopping the progress forwarder after the drain grace period"
+                );
+                forwarder.abort();
+            }
+            result
+        }
+        None => {
+            tool.execute(params, &context)
+                .instrument(tracing::debug_span!("tool_execute", tool = %tool_name))
+                .await
+        }
+    };
+
+    let result = match exec_result {
         Ok(result) => result,
         Err(e) => {
             tracing::warn!(tool = %tool_name, error = %e, "Tool execution failed");
@@ -334,6 +408,17 @@ async fn execute_tool_inner(
 
     let duration_ms = start.elapsed().as_millis() as u64;
     tracing::debug!(tool = %tool_name, duration_ms, "Tool completed");
+
+    // Loop-generated `Completed` bookend — emitted right before `ToolCallCompleted`,
+    // reusing the same `start.elapsed()` measurement so it matches
+    // `ToolCallCompleted.duration_ms`.
+    event_emitter.emit(HiveEvent::ToolProgress {
+        timestamp_ms: pulsehive_core::event::now_ms(),
+        agent_id: agent_id.to_string(),
+        tool_name: tool_name.to_string(),
+        progress: ToolProgress::Completed { duration_ms },
+    });
+
     let result_preview: String = result.to_content().chars().take(200).collect();
     event_emitter.emit(HiveEvent::ToolCallCompleted {
         timestamp_ms: pulsehive_core::event::now_ms(),
@@ -957,6 +1042,167 @@ mod tests {
         assert_eq!(
             perceive_count, 1,
             "With refresh=Some(10) and 1 tool call, should have exactly 1 SubstratePerceived. Got {perceive_count}"
+        );
+    }
+
+    // ── Streaming tool-progress wiring tests (WI 1.03) ───────────────────
+
+    use pulsehive_core::tool::StreamingTool;
+
+    // Mock streaming tool: pushes a deterministic
+    // Progress(0.5) → PartialResult → Progress(1.0) sequence over its channel and
+    // never sends `Started`/`Completed` (those are loop bookends). No sleeps, so
+    // ordering assertions are deterministic.
+    struct ProgressTool;
+
+    #[async_trait]
+    impl Tool for ProgressTool {
+        fn name(&self) -> &str {
+            "progress"
+        }
+        fn description(&self) -> &str {
+            "streaming mock that emits intermediate progress"
+        }
+        fn parameters(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+        async fn execute(
+            &self,
+            _params: serde_json::Value,
+            _ctx: &ToolContext,
+        ) -> Result<ToolResult> {
+            Ok(ToolResult::text("progress-done"))
+        }
+        fn as_streaming(&self) -> Option<&dyn StreamingTool> {
+            Some(self)
+        }
+    }
+
+    #[async_trait]
+    impl StreamingTool for ProgressTool {
+        async fn execute_streaming(
+            &self,
+            _params: serde_json::Value,
+            _context: &ToolContext,
+            progress_tx: mpsc::Sender<ToolProgress>,
+        ) -> Result<ToolResult> {
+            let _ = progress_tx
+                .send(ToolProgress::Progress {
+                    fraction: 0.5,
+                    message: None,
+                })
+                .await;
+            let _ = progress_tx
+                .send(ToolProgress::PartialResult {
+                    payload: serde_json::json!({"n": 1}),
+                })
+                .await;
+            let _ = progress_tx
+                .send(ToolProgress::Progress {
+                    fraction: 1.0,
+                    message: Some("done".into()),
+                })
+                .await;
+            Ok(ToolResult::text("progress-done"))
+        }
+    }
+
+    // Classify only the tool-call envelope events (ToolCallStarted, the loop's
+    // ToolProgress bookends + forwarded intermediate progress, ToolCallCompleted)
+    // into short, order-preserving tags. Non-tool events (Llm*, Substrate*) are
+    // dropped so the envelope ordering can be asserted directly.
+    fn tool_envelope_tags(events: &[HiveEvent]) -> Vec<&'static str> {
+        events
+            .iter()
+            .filter_map(|e| match e {
+                HiveEvent::ToolCallStarted { .. } => Some("ToolCallStarted"),
+                HiveEvent::ToolCallCompleted { .. } => Some("ToolCallCompleted"),
+                HiveEvent::ToolProgress { progress, .. } => Some(match progress {
+                    ToolProgress::Started { .. } => "Started",
+                    ToolProgress::Progress { .. } => "Progress",
+                    ToolProgress::PartialResult { .. } => "PartialResult",
+                    ToolProgress::Log { .. } => "Log",
+                    ToolProgress::Completed { .. } => "Completed",
+                }),
+                _ => None,
+            })
+            .collect()
+    }
+
+    // Drive the loop with a single tool call, subscribing BEFORE the run and
+    // draining promptly after into a Vec (event count << broadcast cap 256, so no
+    // lag drop is possible for this deterministic set).
+    async fn run_loop_collect(tools: Vec<Arc<dyn Tool>>) -> Vec<HiveEvent> {
+        let provider = Arc::new(MockLlm::new(vec![
+            MockLlm::tool_call_response("call_1", tools[0].name(), serde_json::json!({})),
+            MockLlm::text_response("Done"),
+        ]));
+        let config = test_config(tools);
+        let task = test_task();
+        let substrate = test_substrate();
+        let emitter = EventEmitter::default();
+        let mut rx = emitter.subscribe();
+        let approval = pulsehive_core::approval::AutoApprove;
+
+        let _outcome = run_agentic_loop(
+            config,
+            LoopContext {
+                agent_id: "agent-streaming".into(),
+                task: &task,
+                provider,
+                substrate,
+                approval_handler: &approval,
+                event_emitter: emitter,
+                max_iterations: DEFAULT_MAX_ITERATIONS,
+                embedding_provider: None,
+            },
+        )
+        .await;
+
+        let mut events = vec![];
+        while let Ok(e) = rx.try_recv() {
+            events.push(e);
+        }
+        events
+    }
+
+    #[tokio::test]
+    async fn plain_tool_streaming_bookends() {
+        // A non-streaming tool must still yield exactly the loop-generated envelope:
+        // ToolCallStarted → ToolProgress::Started → ToolProgress::Completed → ToolCallCompleted.
+        let events = run_loop_collect(vec![Arc::new(EchoTool)]).await;
+        let tags = tool_envelope_tags(&events);
+        assert_eq!(
+            tags,
+            vec![
+                "ToolCallStarted",
+                "Started",
+                "Completed",
+                "ToolCallCompleted"
+            ],
+            "plain tool must produce the exact Started→Completed envelope. Tags: {tags:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn streaming_tool_progress_ordering() {
+        // A streaming tool's intermediate ToolProgress events must appear in send
+        // order, bracketed by the loop's Started/Completed bookends and the
+        // ToolCall* envelope.
+        let events = run_loop_collect(vec![Arc::new(ProgressTool)]).await;
+        let tags = tool_envelope_tags(&events);
+        assert_eq!(
+            tags,
+            vec![
+                "ToolCallStarted",
+                "Started",
+                "Progress",
+                "PartialResult",
+                "Progress",
+                "Completed",
+                "ToolCallCompleted"
+            ],
+            "streaming tool must emit intermediate progress in send order between bookends. Tags: {tags:?}"
         );
     }
 }

--- a/pulsehive-runtime/tests/streaming_test.rs
+++ b/pulsehive-runtime/tests/streaming_test.rs
@@ -1,0 +1,285 @@
+//! Integration test for the agent-loop streaming wiring (WI 1.03).
+//!
+//! Drives the full `HiveMind::deploy()` → agentic loop → event stream path with a
+//! streaming tool that emits `ToolProgress::Progress` over ~1s, and asserts that a
+//! subscriber sees the live progress plus the loop-generated `Started`/`Completed`
+//! bookends.
+//!
+//! Broadcast-drain discipline (audit ②): the `deploy()` stream subscribes BEFORE
+//! the agent runs and `collect_events` drains promptly; progress-count assertions
+//! use `>=`, never `==`, because the `EventBus` is a lossy `tokio::broadcast`.
+
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use futures_core::Stream;
+use serde_json::Value;
+
+use pulsehive_core::agent::{AgentDefinition, AgentKind, AgentOutcome, LlmAgentConfig};
+use pulsehive_core::error::{PulseHiveError, Result};
+use pulsehive_core::event::HiveEvent;
+use pulsehive_core::lens::Lens;
+use pulsehive_core::llm::{
+    LlmChunk, LlmConfig, LlmProvider, LlmResponse, Message, TokenUsage, ToolCall, ToolDefinition,
+};
+use pulsehive_core::tool::{StreamingTool, Tool, ToolContext, ToolProgress, ToolResult};
+use pulsehive_runtime::hivemind::{HiveMind, Task};
+use tokio::sync::mpsc;
+
+// ── Mock LLM Provider ────────────────────────────────────────────────────
+
+/// Scripted LLM: returns one tool call for `sleepy_stream`, then a final text.
+struct ScriptedLlm {
+    responses: Mutex<Vec<LlmResponse>>,
+}
+
+impl ScriptedLlm {
+    fn new(responses: Vec<LlmResponse>) -> Self {
+        Self {
+            responses: Mutex::new(responses),
+        }
+    }
+
+    fn text(content: &str) -> LlmResponse {
+        LlmResponse {
+            content: Some(content.into()),
+            tool_calls: vec![],
+            usage: TokenUsage::default(),
+        }
+    }
+
+    fn tool_call(id: &str, name: &str, args: Value) -> LlmResponse {
+        LlmResponse {
+            content: None,
+            tool_calls: vec![ToolCall {
+                id: id.into(),
+                name: name.into(),
+                arguments: args,
+            }],
+            usage: TokenUsage::default(),
+        }
+    }
+}
+
+#[async_trait]
+impl LlmProvider for ScriptedLlm {
+    async fn chat(
+        &self,
+        _messages: Vec<Message>,
+        _tools: Vec<ToolDefinition>,
+        _config: &LlmConfig,
+    ) -> Result<LlmResponse> {
+        let mut responses = self.responses.lock().unwrap();
+        if responses.is_empty() {
+            Err(PulseHiveError::llm("No more scripted responses"))
+        } else {
+            Ok(responses.remove(0))
+        }
+    }
+
+    async fn chat_stream(
+        &self,
+        _messages: Vec<Message>,
+        _tools: Vec<ToolDefinition>,
+        _config: &LlmConfig,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<LlmChunk>> + Send>>> {
+        Err(PulseHiveError::llm("Streaming not used in loop"))
+    }
+}
+
+// ── Streaming tool that emits progress every ~200ms for ~1s ───────────────
+
+const PROGRESS_STEPS: usize = 5;
+const STEP_MS: u64 = 200;
+
+struct SleepyStreamingTool;
+
+#[async_trait]
+impl Tool for SleepyStreamingTool {
+    fn name(&self) -> &str {
+        "sleepy_stream"
+    }
+    fn description(&self) -> &str {
+        "Long-running tool that reports fractional progress"
+    }
+    fn parameters(&self) -> Value {
+        serde_json::json!({"type": "object"})
+    }
+    // Non-streaming fallback (never taken here — `as_streaming` returns `Some`).
+    async fn execute(&self, _params: Value, _ctx: &ToolContext) -> Result<ToolResult> {
+        Ok(ToolResult::text("done (non-streaming path)"))
+    }
+    fn as_streaming(&self) -> Option<&dyn StreamingTool> {
+        Some(self)
+    }
+}
+
+#[async_trait]
+impl StreamingTool for SleepyStreamingTool {
+    async fn execute_streaming(
+        &self,
+        _params: Value,
+        _context: &ToolContext,
+        progress_tx: mpsc::Sender<ToolProgress>,
+    ) -> Result<ToolResult> {
+        for step in 1..=PROGRESS_STEPS {
+            tokio::time::sleep(Duration::from_millis(STEP_MS)).await;
+            // Dropped receiver is a soft signal: ignore send errors, keep going.
+            let _ = progress_tx
+                .send(ToolProgress::Progress {
+                    fraction: step as f32 / PROGRESS_STEPS as f32,
+                    message: Some(format!("step {step}/{PROGRESS_STEPS}")),
+                })
+                .await;
+        }
+        Ok(ToolResult::text("stream complete"))
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+fn build_hive(provider: ScriptedLlm) -> HiveMind {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test.db");
+    // Leak the tempdir so its files outlive the test.
+    Box::leak(Box::new(dir));
+
+    HiveMind::builder()
+        .substrate_path(&path)
+        .llm_provider("mock", provider)
+        .build()
+        .unwrap()
+}
+
+fn llm_agent(name: &str, tools: Vec<Arc<dyn Tool>>) -> AgentDefinition {
+    AgentDefinition {
+        name: name.into(),
+        kind: AgentKind::Llm(Box::new(LlmAgentConfig {
+            system_prompt: "You are a test agent.".into(),
+            tools,
+            lens: Lens::default(),
+            llm_config: LlmConfig::new("mock", "test-model"),
+            experience_extractor: None,
+            refresh_every_n_tool_calls: None,
+        })),
+    }
+}
+
+/// Drain the event stream promptly until the agent completes (or timeout).
+async fn collect_events(
+    mut stream: Pin<Box<dyn Stream<Item = HiveEvent> + Send>>,
+    timeout: Duration,
+) -> Vec<HiveEvent> {
+    let mut events = vec![];
+    let deadline = tokio::time::Instant::now() + timeout;
+
+    loop {
+        tokio::select! {
+            event = stream.next() => {
+                match event {
+                    Some(e) => {
+                        let is_completed = matches!(&e, HiveEvent::AgentCompleted { .. });
+                        events.push(e);
+                        if is_completed { break; }
+                    }
+                    None => break,
+                }
+            }
+            _ = tokio::time::sleep_until(deadline) => { break; }
+        }
+    }
+
+    events
+}
+
+// ── Test ────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn streaming_tool_progress_reaches_subscriber() {
+    let provider = ScriptedLlm::new(vec![
+        ScriptedLlm::tool_call("call_1", "sleepy_stream", serde_json::json!({})),
+        ScriptedLlm::text("All done."),
+    ]);
+    let hive = build_hive(provider);
+
+    let agent = llm_agent("streamer", vec![Arc::new(SleepyStreamingTool)]);
+    let task = Task::new("Run the long streaming tool");
+
+    let t0 = std::time::Instant::now();
+    let stream = hive.deploy(vec![agent], vec![task]).await.unwrap();
+    let events = collect_events(stream, Duration::from_secs(10)).await;
+    let elapsed_ms = t0.elapsed().as_millis() as u64;
+
+    // Intermediate progress: at least 4 `Progress` events reached the subscriber.
+    let progress_count = events
+        .iter()
+        .filter(|e| {
+            matches!(
+                e,
+                HiveEvent::ToolProgress {
+                    progress: ToolProgress::Progress { .. },
+                    ..
+                }
+            )
+        })
+        .count();
+    assert!(
+        progress_count >= 4,
+        "expected >= 4 ToolProgress::Progress events, got {progress_count}. Events: {events:?}"
+    );
+
+    // Loop-generated `Started` bookend present.
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            HiveEvent::ToolProgress {
+                progress: ToolProgress::Started { .. },
+                ..
+            }
+        )),
+        "missing loop-generated ToolProgress::Started bookend. Events: {events:?}"
+    );
+
+    // Loop-generated `Completed` bookend present; capture its duration.
+    let duration_ms = events
+        .iter()
+        .find_map(|e| match e {
+            HiveEvent::ToolProgress {
+                progress: ToolProgress::Completed { duration_ms },
+                ..
+            } => Some(*duration_ms),
+            _ => None,
+        })
+        .expect("missing loop-generated ToolProgress::Completed bookend");
+
+    // `Completed.duration_ms` reflects the ~1s of streaming work…
+    assert!(
+        duration_ms >= 800,
+        "tool duration {duration_ms}ms should reflect ~1s of streaming work (>= 800ms)"
+    );
+    // …and is ≈ the loop's wall-clock elapsed (mocks + deploy overhead are small).
+    assert!(
+        duration_ms <= elapsed_ms + 50,
+        "tool duration {duration_ms}ms cannot meaningfully exceed loop elapsed {elapsed_ms}ms"
+    );
+    assert!(
+        elapsed_ms - duration_ms < 2000,
+        "tool duration {duration_ms}ms should be ≈ loop elapsed {elapsed_ms}ms"
+    );
+
+    // Sanity: the agent completed successfully through the streaming tool call.
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            HiveEvent::AgentCompleted {
+                outcome: AgentOutcome::Complete { response },
+                ..
+            } if response == "All done."
+        )),
+        "expected AgentCompleted(Complete). Events: {events:?}"
+    );
+}


### PR DESCRIPTION
Closes sprint-1.1 at 1/4 completion (VS-1.1.1 merged).

Remaining slices (VS-1.1.2/1.1.3/1.1.4) will be planned under ossify Release 1.

Prepared for ossify adoption.