### PR TITLE
docs: add ADR series 001-010 (adoption + nine architectural bones)

### DIFF
--- a/docs/adr/001-ossify-adoption.md
+++ b/docs/adr/001-ossify-adoption.md
@@ -48,12 +48,12 @@ Adopt ossify 1.0.3 as the development workflow framework, retiring scaffold-dev.
 - AI workspace artifacts maintained (memory-bank, MASTER-SPEC.md)
 
 **Negative:**
-- No ADR directory existed at adoption (created, bones back-derivation skipped)
+- No ADR directory existed at adoption; it was created immediately after, and ADRs 002–010 are that back-derivation of the baseline's nine bones
 - Sprint 1.1 partial completion required explicit handoff to Release 1
 
 ## Implementation
 
-**Adoption Record:** See `/Users/draco/projects/PulseHive/pulsehive-ai/ADOPTION.md`
+**Adoption Record:** The adoption record is summarized by this ADR; the full record lives in the private ossify workspace and is not part of this repository.
 
 **Next Steps:**
 - `/ossify:plan-release` for Release 1 feature mapping
@@ -63,5 +63,4 @@ Adopt ossify 1.0.3 as the development workflow framework, retiring scaffold-dev.
 ## References
 
 - Ossify 1.0.3 adoption ceremony: `/ossify:adopt`
-- Build session protocol: claude-agent-scaffolding-ai-52
 - Baseline SHA: 60503db38514a4a4d5d6e6405a6dc2465dd9744a

--- a/docs/adr/001-ossify-adoption.md
+++ b/docs/adr/001-ossify-adoption.md
@@ -1,0 +1,67 @@
+# ADR 001: Ossify Adoption
+
+**Status:** Accepted
+**Date:** 2026-08-23
+**Context:** Adoption ceremony from scaffold-dev to ossify 1.0.3
+
+## Context
+
+PulseHive was developed using the scaffold-dev workflow (sprint → slice → work-item loop). As the project matured beyond v2.0.1 with multiple slices planned for v2.1.0, the need arose for:
+- Formal architectural decision tracking (bones registry)
+- Release-level planning with exit criteria
+- Ceremony-driven development with fail-closed gates
+- Retrospective recording and harvest discipline
+
+## Decision
+
+Adopt ossify 1.0.3 as the development workflow framework, retiring scaffold-dev.
+
+### Adoption Details
+
+**Baseline:** Release 0, closed retroactively at SHA 60503db
+- v2.0.1 shipped: five primitives, agentic loop, intelligence layer, providers, bindings
+- VS-1.1.1 shipped: streaming tool execution + ToolProgress events
+
+**Transition:**
+- Sprint 1.1 closed at 1/4 completion (VS-1.1.1 merged via PR #44)
+- Remaining slices (VS-1.1.2/1.1.3/1.1.4) handed to Release 1 for planning
+- scaffold-dev ceremonies retired
+- ossify ceremonies activated (`/ossify:*` slash commands)
+
+**Rationale:**
+- Ossify provides ADR-backed bones (nine categories with touch surfaces)
+- Release planning with feature mapping and exit criteria
+- Fail-closed gates at every ceremony (adoption, planning, execution, close)
+- Retrospective discipline with harvest → known-issues/decisions-log
+
+### Consequences
+
+**Positive:**
+- Structured release planning with `/ossify:plan-release`
+- Architectural decisions tracked as bones with touch glob triggers
+- Demo-ledger discipline (seed candidates recorded, exercised at spine close)
+- State-driven workflow (project-state.json as source of truth)
+
+**Neutral:**
+- Learning curve for ossify ceremonies
+- Legacy scaffold-dev stack preserved but inactive
+- AI workspace artifacts maintained (memory-bank, MASTER-SPEC.md)
+
+**Negative:**
+- No ADR directory existed at adoption (created, bones back-derivation skipped)
+- Sprint 1.1 partial completion required explicit handoff to Release 1
+
+## Implementation
+
+**Adoption Record:** See `/Users/draco/projects/PulseHive/pulsehive-ai/ADOPTION.md`
+
+**Next Steps:**
+- `/ossify:plan-release` for Release 1 feature mapping
+- Plan first spine with VS-1.1.2 (cancellation infrastructure)
+- Author bones forward starting with Release 1
+
+## References
+
+- Ossify 1.0.3 adoption ceremony: `/ossify:adopt`
+- Build session protocol: claude-agent-scaffolding-ai-52
+- Baseline SHA: 60503db38514a4a4d5d6e6405a6dc2465dd9744a

--- a/docs/adr/001-ossify-adoption.md
+++ b/docs/adr/001-ossify-adoption.md
@@ -6,7 +6,7 @@
 
 ## Context
 
-PulseHive was developed using the scaffold-dev workflow (sprint → slice → work-item loop). As the project matured beyond v2.0.1 with multiple slices planned for v2.1.0, the need arose for:
+PulseHive was developed using the scaffold-dev workflow (sprint → slice → work-item loop). As the project matured beyond v2.0.2 with multiple slices planned for v2.1.0, the need arose for:
 - Formal architectural decision tracking (bones registry)
 - Release-level planning with exit criteria
 - Ceremony-driven development with fail-closed gates
@@ -19,14 +19,14 @@ Adopt ossify 1.0.3 as the development workflow framework, retiring scaffold-dev.
 ### Adoption Details
 
 **Baseline:** Release 0, closed retroactively at SHA 60503db
-- v2.0.1 shipped: five primitives, agentic loop, intelligence layer, providers, bindings
+- v2.0.2 shipped: five primitives, agentic loop, intelligence layer, providers, bindings
 - VS-1.1.1 shipped: streaming tool execution + ToolProgress events
 
 **Transition:**
 - Sprint 1.1 closed at 1/4 completion (VS-1.1.1 merged via PR #44)
 - Remaining slices (VS-1.1.2/1.1.3/1.1.4) handed to Release 1 for planning
 - scaffold-dev ceremonies retired
-- ossify ceremonies activated (`/ossify:*` slash commands)
+- ossify ceremonies activated (`/ossify:*` slash commands in the ossify workspace, not repository files)
 
 **Rationale:**
 - Ossify provides ADR-backed bones (nine categories with touch surfaces)
@@ -37,7 +37,7 @@ Adopt ossify 1.0.3 as the development workflow framework, retiring scaffold-dev.
 ### Consequences
 
 **Positive:**
-- Structured release planning with `/ossify:plan-release`
+- Structured release planning with the ossify workspace's plan-release ceremony
 - Architectural decisions tracked as bones with touch glob triggers
 - Demo-ledger discipline (seed candidates recorded, exercised at spine close)
 - State-driven workflow (project-state.json as source of truth)
@@ -56,11 +56,11 @@ Adopt ossify 1.0.3 as the development workflow framework, retiring scaffold-dev.
 **Adoption Record:** The adoption record is summarized by this ADR; the full record lives in the private ossify workspace and is not part of this repository.
 
 **Next Steps:**
-- `/ossify:plan-release` for Release 1 feature mapping
+- Release 1 feature mapping via the ossify workspace's plan-release ceremony
 - Plan first spine with VS-1.1.2 (cancellation infrastructure)
 - Author bones forward starting with Release 1
 
 ## References
 
-- Ossify 1.0.3 adoption ceremony: `/ossify:adopt`
+- Ossify 1.0.3 adoption ceremony: `/ossify:adopt` (ossify-workspace slash command, not a repository file)
 - Baseline SHA: 60503db38514a4a4d5d6e6405a6dc2465dd9744a

--- a/docs/adr/002-system-shape.md
+++ b/docs/adr/002-system-shape.md
@@ -15,7 +15,7 @@ PulseHive is a library/SDK, not a deployed service. It runs in the caller's proc
 - PulseHive runs in the calling application's process
 - No separate deployment topology
 - No client-server split within PulseHive itself
-- Deployment unit is the crate (published to crates.io)
+- Distribution unit is the crate (published to crates.io); the deployment unit is the consuming application
 
 **Rationale:** As an SDK, PulseHive's runtime is embedded in consumer applications. Splitting into separate deployables would require measured pressure that the product imposes, not anticipatory scaling.
 

--- a/docs/adr/002-system-shape.md
+++ b/docs/adr/002-system-shape.md
@@ -15,14 +15,14 @@ PulseHive is a library/SDK, not a deployed service. It runs in the caller's proc
 - PulseHive runs in the calling application's process
 - No separate deployment topology
 - No client-server split within PulseHive itself
-- Distribution unit is the crate (published to crates.io); the deployment unit is the consuming application
+- Distribution units are the crates.io crate, the PyPI wheels/sdist, and the npm `@pulsehive/sdk` package; the deployment unit is the consuming application
 
 **Rationale:** As an SDK, PulseHive's runtime is embedded in consumer applications. Splitting into separate deployables would require measured pressure that the product imposes, not anticipatory scaling.
 
 ## Consequences
 
 **Positive:**
-- Simple deployment model - consumers depend on crates.io published version
+- Simple deployment model - consumers install from crates.io, PyPI, or npm
 - No inter-process communication complexity
 - Direct access to PulseHive APIs in consumer code
 

--- a/docs/adr/002-system-shape.md
+++ b/docs/adr/002-system-shape.md
@@ -1,0 +1,39 @@
+# ADR 002: System Shape & Deployment Topology
+
+**Status:** Accepted
+**Category:** 1 - System shape & deployment topology
+**Touch Surface:** `pulsehive-*/src/`
+**Revisit Trigger:** When spawning separate runtime processes
+
+## Context
+
+PulseHive is a library/SDK, not a deployed service. It runs in the caller's process.
+
+## Decision
+
+**System Shape:** In-process library SDK
+- PulseHive runs in the calling application's process
+- No separate deployment topology
+- No client-server split within PulseHive itself
+- Deployment unit is the crate (published to crates.io)
+
+**Rationale:** As an SDK, PulseHive's runtime is embedded in consumer applications. Splitting into separate deployables would require measured pressure that the product imposes, not anticipatory scaling.
+
+## Consequences
+
+**Positive:**
+- Simple deployment model - consumers depend on crates.io published version
+- No inter-process communication complexity
+- Direct access to PulseHive APIs in consumer code
+
+**Neutral:**
+- PulseHive lifecycle tied to consumer application lifecycle
+- Resource consumption (threads, memory) happens in consumer process
+
+**Negative:**
+- Consumer responsible for their own deployment topology
+- PulseHive cannot impose separate runtime processes without consumer awareness
+
+## Implementation
+
+Baseline 60503db ships as in-process library. All primitives (HiveMind, Agent, Tool, Lens, Experience) operate within the consuming application's process space.

--- a/docs/adr/002-system-shape.md
+++ b/docs/adr/002-system-shape.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted
 **Category:** 1 - System shape & deployment topology
-**Touch Surface:** `pulsehive-*/src/`
+**Touch Surface:** `pulsehive*/src/`
 **Revisit Trigger:** When spawning separate runtime processes
 
 ## Context

--- a/docs/adr/003-module-boundaries.md
+++ b/docs/adr/003-module-boundaries.md
@@ -1,0 +1,37 @@
+# ADR 003: Module Boundaries & Dependency Direction
+
+**Status:** Accepted
+**Category:** 2 - Module boundaries & dependency direction
+**Touch Surface:** `pulsehive-core/src/`
+**Revisit Trigger:** When adding sixth primitive or blurring PulseDB boundary
+
+## Context
+
+PulseHive is organized around five core primitives with strict separation from the substrate layer.
+
+## Decision
+
+**Module Boundaries:**
+- **Five primitives hard cap:** HiveMind, Agent, Tool, Lens, Experience
+- **PulseDB strict separation:** PulseHive owns intelligence layer; PulseDB owns storage
+- **Dependency direction:** PulseHive → PulseDB (never reverse)
+- **Core module:** `pulsehive-core` defines primitive interfaces
+- **Provider modules:** `pulsehive-anthropic`, `pulsehive-openai` implement LlmProvider trait
+- **Runtime module:** `pulsehive-runtime` implements agentic loop and workflow execution
+
+**Rationale:** The five-primitive boundary keeps the framework small enough to reason about. PulseDB separation ensures substrate independence. Dependency direction prevents tight coupling to storage implementation.
+
+## Consequences
+
+**Positive:**
+- Clear, bounded surface area
+- Substrate portability (PulseDB can evolve independently)
+- Provider abstraction enables multiple LLM backends
+
+**Neutral:**
+- New primitive requires strong justification
+- Provider changes isolated to specific crates
+
+**Negative:**
+- Cannot add sixth primitive without demonstrated need
+- PulseDB cannot depend on PulseHive features

--- a/docs/adr/003-module-boundaries.md
+++ b/docs/adr/003-module-boundaries.md
@@ -15,7 +15,7 @@ PulseHive is organized around five core primitives with strict separation from t
 - **Five primitives hard cap:** HiveMind, Agent, Tool, Lens, Experience
 - **PulseDB strict separation:** PulseHive owns intelligence layer; PulseDB owns storage
 - **Dependency direction:** PulseHive → PulseDB (never reverse)
-- **Primitive homes:** `pulsehive-core` defines the Agent, Tool, and Lens interfaces; `HiveMind` and its builder are defined in `pulsehive-runtime/src/hivemind.rs`; `Experience` is defined by PulseDB and re-exported by `pulsehive-core`
+- **Primitive homes:** `pulsehive-core` defines the Agent and Tool interfaces and the concrete `Lens` value type; `HiveMind` and its builder are defined in `pulsehive-runtime/src/hivemind.rs`; `Experience` is defined by PulseDB and re-exported by `pulsehive-core`
 - **Provider modules:** `pulsehive-anthropic`, `pulsehive-openai` implement LlmProvider trait
 - **Runtime module:** `pulsehive-runtime` implements agentic loop and workflow execution
 

--- a/docs/adr/003-module-boundaries.md
+++ b/docs/adr/003-module-boundaries.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted
 **Category:** 2 - Module boundaries & dependency direction
-**Touch Surface:** `pulsehive-core/src/`
+**Touch Surface:** `pulsehive/src/,pulsehive-core/src/,pulsehive-runtime/src/,pulsehive-openai/src/,pulsehive-anthropic/src/,pulsehive-py/src/,pulsehive-js/src/`
 **Revisit Trigger:** When adding sixth primitive or blurring PulseDB boundary
 
 ## Context

--- a/docs/adr/003-module-boundaries.md
+++ b/docs/adr/003-module-boundaries.md
@@ -15,7 +15,7 @@ PulseHive is organized around five core primitives with strict separation from t
 - **Five primitives hard cap:** HiveMind, Agent, Tool, Lens, Experience
 - **PulseDB strict separation:** PulseHive owns intelligence layer; PulseDB owns storage
 - **Dependency direction:** PulseHive → PulseDB (never reverse)
-- **Core module:** `pulsehive-core` defines primitive interfaces
+- **Primitive homes:** `pulsehive-core` defines the Agent, Tool, and Lens interfaces; `HiveMind` and its builder are defined in `pulsehive-runtime/src/hivemind.rs`; `Experience` is defined by PulseDB and re-exported by `pulsehive-core`
 - **Provider modules:** `pulsehive-anthropic`, `pulsehive-openai` implement LlmProvider trait
 - **Runtime module:** `pulsehive-runtime` implements agentic loop and workflow execution
 

--- a/docs/adr/004-data-ownership.md
+++ b/docs/adr/004-data-ownership.md
@@ -1,0 +1,40 @@
+# ADR 004: Data Ownership & Migration Posture
+
+**Status:** Accepted
+**Category:** 3 - Data ownership & migration posture
+**Touch Surface:** `pulsehive-runtime/src/`
+**Revisit Trigger:** When introducing in-process persistence
+
+## Context
+
+PulseHive processes agent experiences but does not own the persistent storage layer.
+
+## Decision
+
+**Data Ownership:**
+- **PulseDB owns storage:** Vectors, graph, watch system, context assembly
+- **PulseHive owns intelligence:** Attractor dynamics, lens warping, conflict reasoning, insight synthesis
+- **Consumer owns PulseDB instance:** Substrate path provided by consumer
+- **No in-process persistence:** PulseHive does not embed database
+
+**Migration Posture:** Expand/contract via PulseDB
+- PulseHive operates through substrate abstraction
+- Schema changes managed at PulseDB level
+- PulseHive queries through versioned substrate interface
+
+**Rationale:** Clear ownership boundaries prevent responsibility confusion. PulseHive's intelligence layer operates on data PulseDB owns and persists. Consumers control substrate lifecycle.
+
+## Consequences
+
+**Positive:**
+- Clear separation of concerns
+- PulseDB can evolve independently
+- Consumers control persistence lifecycle
+
+**Neutral:**
+- PulseHive cannot define its own persistence schema
+- Migration complexity delegated to substrate
+
+**Negative:**
+- PulseHive cannot optimize storage for specific intelligence operations
+- Substrate bugs affect PulseHive (dependency risk)

--- a/docs/adr/004-data-ownership.md
+++ b/docs/adr/004-data-ownership.md
@@ -3,7 +3,7 @@
 **Status:** Accepted
 **Category:** 3 - Data ownership & migration posture
 **Touch Surface:** `pulsehive-runtime/src/`
-**Revisit Trigger:** When introducing in-process persistence
+**Revisit Trigger:** When PulseHive starts owning persistence or bypassing the substrate abstraction
 
 ## Context
 
@@ -15,7 +15,7 @@ PulseHive processes agent experiences but does not own the persistent storage la
 - **PulseDB owns storage:** Vectors, graph, watch system, context assembly
 - **PulseHive owns intelligence:** Attractor dynamics, lens warping, conflict reasoning, insight synthesis
 - **Consumer owns PulseDB instance:** Substrate path provided by consumer
-- **No in-process persistence:** PulseHive does not embed database
+- **Execution location, not ownership:** PulseHive does not own persistence, but it does run the database engine in-process — `HiveMindBuilder::build()` opens PulseDB at the consumer-configured substrate path inside the consumer's process and wraps it in `PulseDBSubstrate` (`pulsehive-runtime/src/hivemind.rs`)
 
 **Migration Posture:** Expand/contract via PulseDB
 - PulseHive operates through substrate abstraction

--- a/docs/adr/005-public-contracts.md
+++ b/docs/adr/005-public-contracts.md
@@ -16,7 +16,7 @@ PulseHive is published as a library crate with multiple downstream consumers.
 - **Breaking change policy:** Breaking changes batched into next major version
 - **Additive evolution:** Minor releases never break consumers (v2.1.0 exception: `HiveEvent` variants were added under `#[non_exhaustive]` without a major bump — see Event contracts below)
 - **License:** AGPL-3.0-only (open-source option), commercial license available
-- **Documentation guarantees:** Public APIs documented with compiling doc-tests
+- **Documentation guarantees:** Public APIs are documented and `cargo doc` checks the documentation builds; public examples are currently marked `rust,ignore`, so doc-tests do not compile them (wiring examples into compiled doc-tests is tracked in #58)
 
 **Compatibility:**
 - **Trait contracts:** Every public trait in PulseHive's published crates is a stable interface: `LlmProvider`, `EmbeddingProvider`, `EventExporter`, `Tool`, `StreamingTool`, `ApprovalHandler`, and `ExperienceExtractor`, all defined in `pulsehive-core` (the only crate defining public traits)

--- a/docs/adr/005-public-contracts.md
+++ b/docs/adr/005-public-contracts.md
@@ -1,0 +1,41 @@
+# ADR 005: Public Contracts & Compatibility Policy
+
+**Status:** Accepted
+**Category:** 4 - Public contracts & compatibility policy
+**Touch Surface:** `pulsehive-*/src/`
+**Revisit Trigger:** When breaking changes needed
+
+## Context
+
+PulseHive is published as a library crate with multiple downstream consumers.
+
+## Decision
+
+**Public Contracts:**
+- **API stability:** Semantic versioning (MAJOR.MINOR.PATCH)
+- **Breaking change policy:** Breaking changes batched into next major version
+- **Additive evolution:** Minor releases never break consumers
+- **License:** AGPL-3.0-only (open-source option), commercial license available
+- **Documentation guarantees:** Public APIs documented with compiling doc-tests
+
+**Compatibility:**
+- **Trait contracts:** LlmProvider, StreamingTool, Lens are stable interfaces
+- **Event contracts:** HiveEvent enum is `#[non_exhaustive]` (v2.1.0 exception)
+- **Binding contracts:** PyO3 (Python) and napi-rs (TypeScript) APIs follow Rust semantics
+
+**Rationale:** Downstream consumers (DevStudio, PulseTrader) require stability. Semantic versioning provides clear compatibility signals. Additive evolution within majors respects consumer upgrade cadence.
+
+## Consequences
+
+**Positive:**
+- Predictable upgrade paths for consumers
+- Clear backward compatibility guarantees
+- Commercial licensing option for proprietary use
+
+**Neutral:**
+- Breaking changes require major version bump
+- Consumer testing required for minor upgrades
+
+**Negative:**
+- Cannot ship breaking changes in minor releases
+- Contract changes require careful coordination across bindings

--- a/docs/adr/005-public-contracts.md
+++ b/docs/adr/005-public-contracts.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted
 **Category:** 4 - Public contracts & compatibility policy
-**Touch Surface:** `pulsehive-*/src/`
+**Touch Surface:** `pulsehive*/src/`
 **Revisit Trigger:** When breaking changes needed
 
 ## Context

--- a/docs/adr/005-public-contracts.md
+++ b/docs/adr/005-public-contracts.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted
 **Category:** 4 - Public contracts & compatibility policy
-**Touch Surface:** `pulsehive*/src/`
+**Touch Surface:** `pulsehive*/src/,pulsehive-js/package.json,pulsehive-js/wrapper.d.ts,pulsehive-py/python/pulsehive/__init__.py`
 **Revisit Trigger:** When breaking changes needed
 
 ## Context

--- a/docs/adr/005-public-contracts.md
+++ b/docs/adr/005-public-contracts.md
@@ -14,14 +14,15 @@ PulseHive is published as a library crate with multiple downstream consumers.
 **Public Contracts:**
 - **API stability:** Semantic versioning (MAJOR.MINOR.PATCH)
 - **Breaking change policy:** Breaking changes batched into next major version
-- **Additive evolution:** Minor releases never break consumers
+- **Additive evolution:** Minor releases never break consumers (v2.1.0 exception: `HiveEvent` variants were added under `#[non_exhaustive]` without a major bump — see Event contracts below)
 - **License:** AGPL-3.0-only (open-source option), commercial license available
 - **Documentation guarantees:** Public APIs documented with compiling doc-tests
 
 **Compatibility:**
-- **Trait contracts:** LlmProvider, StreamingTool, Lens are stable interfaces
-- **Event contracts:** HiveEvent enum is `#[non_exhaustive]` (v2.1.0 exception)
-- **Binding contracts:** PyO3 (Python) and napi-rs (TypeScript) APIs follow Rust semantics
+- **Trait contracts:** Every public trait in PulseHive's published crates is a stable interface: `LlmProvider`, `EmbeddingProvider`, `EventExporter`, `Tool`, `StreamingTool`, `ApprovalHandler`, and `ExperienceExtractor`, all defined in `pulsehive-core` (the only crate defining public traits)
+- **Value-type contracts:** Stable public value types include `Lens` — a concrete `pub struct` with public mutable fields (`pulsehive-core/src/lens.rs`), configured by construction and field assignment rather than implemented like a trait
+- **Event contracts:** `HiveEvent` enum is `#[non_exhaustive]`; the v2.1.0 exception added variants in a minor release, requiring consumers' `match` arms to keep a wildcard
+- **Binding contracts:** PyO3 (Python) and napi-rs (TypeScript) APIs follow Rust semantics. The JS binding maps `HiveEvent` to `JsHiveEvent` with snake_case event tags, camelCase fields, and a fieldless `unknown` fallback for `HiveEvent` variants the binding does not know; the v2.1.0 `#[non_exhaustive]` exception permits additive Rust variants while preserving that fallback
 
 **Rationale:** Downstream consumers (DevStudio, PulseTrader) require stability. Semantic versioning provides clear compatibility signals. Additive evolution within majors respects consumer upgrade cadence.
 

--- a/docs/adr/006-trust-boundaries.md
+++ b/docs/adr/006-trust-boundaries.md
@@ -13,28 +13,28 @@ PulseHive interfaces with external LLM providers and manages agent tool executio
 
 **Trust Boundaries:**
 - **LlmProvider trait abstraction:** External provider access through trait interface
-- **Provider authentication:** API keys managed by consumer, not stored by PulseHive
-- **Tool execution boundary:** Agents execute tools through defined Tool interface
-- **No destructive operations in library:** PulseHive does not spend money, delete data, or send to third parties directly
+- **Provider authentication:** Consumer supplies the API key; built-in providers retain it as an owned `String` in their config (`OpenAIConfig`, `AnthropicConfig`) for the provider's lifetime, and `AnthropicConfig`'s derived `Debug` can print it (hardening tracked in #56)
+- **Tool execution boundary:** Agents execute tools through the consumer-defined Tool interface; consumer `Tool::execute` implementations can cause arbitrary side effects
+- **Third-party egress and charges:** Built-in providers send authenticated HTTP POSTs to configured third-party endpoints from library code — data disclosure and charges on the consumer's API account are possible
 
 **Destructive Operations:**
-- **Spending money:** Consumer handles API key provision and billing
+- **Spending money:** Library-initiated provider calls can incur charges on the consumer's API account; the consumer controls the key, the model choice, and the endpoints it configures
 - **Deleting data:** PulseHive operates on consumer-provided substrate; consumer owns deletion
-- **Third-party communication:** Provider communication happens through consumer-authenticated channels
+- **Third-party communication:** Provider requests are authenticated with the consumer's key but issued by PulseHive library code, not by the consumer's own runtime
 
-**Rationale:** LlmProvider abstraction prevents hardcoding trust in specific providers. Consumer controls authentication and billing. PulseHive itself performs no irreversible destructive actions.
+**Rationale:** LlmProvider abstraction prevents hardcoding trust in specific providers. The consumer supplies credentials and chooses endpoints and tool implementations, while PulseHive code performs the outbound provider calls — so threat reviews must treat provider traffic (with its disclosure and billing exposure) as SDK behavior, and tool side effects as consumer-controlled.
 
 ## Consequences
 
 **Positive:**
-- Consumer controls all API keys and authentication
+- Consumer supplies all API keys and chooses provider endpoints and tools
 - Provider portability via trait interface
-- No hidden costs or data deletion risks from library itself
+- Egress, charge, and key-retention exposure documented rather than assumed away
 
 **Neutral:**
 - Consumer responsible for provider account management
 - Tool safety delegated to consumer's tool implementations
 
 **Negative:**
-- PulseHive cannot implement features requiring direct billing/deletion
+- Library-initiated provider calls mean data-disclosure and charge risks exist even when the consumer never makes an HTTP call itself
 - Consumer must understand provider trust models

--- a/docs/adr/006-trust-boundaries.md
+++ b/docs/adr/006-trust-boundaries.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted
 **Category:** 5 - Trust boundaries & destructive operations
-**Touch Surface:** `pulsehive-anthropic/src/,pulsehive-openai/src/`
+**Touch Surface:** `pulsehive-core/src/,pulsehive-runtime/src/,pulsehive-anthropic/src/,pulsehive-openai/src/`
 **Revisit Trigger:** When adding provider with different trust model
 
 ## Context

--- a/docs/adr/006-trust-boundaries.md
+++ b/docs/adr/006-trust-boundaries.md
@@ -1,0 +1,40 @@
+# ADR 006: Trust Boundaries & Destructive Operations
+
+**Status:** Accepted
+**Category:** 5 - Trust boundaries & destructive operations
+**Touch Surface:** `pulsehive-anthropic/src/,pulsehive-openai/src/`
+**Revisit Trigger:** When adding provider with different trust model
+
+## Context
+
+PulseHive interfaces with external LLM providers and manages agent tool execution.
+
+## Decision
+
+**Trust Boundaries:**
+- **LlmProvider trait abstraction:** External provider access through trait interface
+- **Provider authentication:** API keys managed by consumer, not stored by PulseHive
+- **Tool execution boundary:** Agents execute tools through defined Tool interface
+- **No destructive operations in library:** PulseHive does not spend money, delete data, or send to third parties directly
+
+**Destructive Operations:**
+- **Spending money:** Consumer handles API key provision and billing
+- **Deleting data:** PulseHive operates on consumer-provided substrate; consumer owns deletion
+- **Third-party communication:** Provider communication happens through consumer-authenticated channels
+
+**Rationale:** LlmProvider abstraction prevents hardcoding trust in specific providers. Consumer controls authentication and billing. PulseHive itself performs no irreversible destructive actions.
+
+## Consequences
+
+**Positive:**
+- Consumer controls all API keys and authentication
+- Provider portability via trait interface
+- No hidden costs or data deletion risks from library itself
+
+**Neutral:**
+- Consumer responsible for provider account management
+- Tool safety delegated to consumer's tool implementations
+
+**Negative:**
+- PulseHive cannot implement features requiring direct billing/deletion
+- Consumer must understand provider trust models

--- a/docs/adr/006-trust-boundaries.md
+++ b/docs/adr/006-trust-boundaries.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted
 **Category:** 5 - Trust boundaries & destructive operations
-**Touch Surface:** `pulsehive-core/src/,pulsehive-runtime/src/,pulsehive-anthropic/src/,pulsehive-openai/src/`
+**Touch Surface:** `pulsehive-core/src/,pulsehive-runtime/src/,pulsehive-anthropic/src/,pulsehive-openai/src/,pulsehive-py/src/,pulsehive-js/src/`
 **Revisit Trigger:** When adding provider with different trust model
 
 ## Context

--- a/docs/adr/007-failure-visibility.md
+++ b/docs/adr/007-failure-visibility.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted
 **Category:** 6 - Failure visibility
-**Touch Surface:** `pulsehive-*/src/`
+**Touch Surface:** `pulsehive*/src/`
 **Revisit Trigger:** When introducing panic paths or silent error swallowing
 
 ## Context

--- a/docs/adr/007-failure-visibility.md
+++ b/docs/adr/007-failure-visibility.md
@@ -1,0 +1,43 @@
+# ADR 007: Failure Visibility
+
+**Status:** Accepted
+**Category:** 6 - Failure visibility
+**Touch Surface:** `pulsehive-*/src/`
+**Revisit Trigger:** When introducing panic paths or silent error swallowing
+
+## Context
+
+PulseHive operates in complex distributed systems (LLM providers, substrate) where failures must be visible and actionable.
+
+## Decision
+
+**Failure Visibility:**
+- **Result types:** Public APIs return `Result<T, E>` for fallible operations
+- **No silent failures:** Library never suppresses errors without explicit consumer acknowledgement
+- **Documented error conditions:** All error variants documented in API docs
+- **Provider failures:** LLM provider errors propagate to consumer
+- **Substrate failures:** PulseDB errors (connection, query) surface through Result types
+
+**What Must Never Fail Silently:**
+- API key authentication failures
+- Substrate connection failures
+- LLM provider outages
+- Tool execution failures
+- Experience corruption
+
+**Rationale:** In agentic systems, silent failures cause incorrect agent behavior. Explicit error handling enables consumers to implement appropriate retry/fallback logic.
+
+## Consequences
+
+**Positive:**
+- Consumers can implement targeted error handling
+- Failures are debuggable and observable
+- No hidden error suppression
+
+**Neutral:**
+- Error handling boilerplate required in consumer code
+- Some operations become fallible that could be infallible in theory
+
+**Negative:**
+- Cannot suppress transient errors without consumer awareness
+- Error propagation requires careful consumer design

--- a/docs/adr/007-failure-visibility.md
+++ b/docs/adr/007-failure-visibility.md
@@ -22,7 +22,7 @@ PulseHive operates in complex distributed systems (LLM providers, substrate) whe
   - relationship detection and insight synthesis log and continue when their substrate queries (`search_similar`, `get_related`) or insight LLM calls fail (`intelligence/`)
 - **Known panic path:** the built-in provider constructors panic via `.expect` if reqwest client construction fails instead of returning `Result` (tracked in #61)
 - **Documented error conditions:** All error variants documented in API docs
-- **Provider failures:** LLM provider errors propagate to consumer
+- **Provider failures:** LLM provider request errors propagate to consumer (constructor client-build failures panic; tracked in #61)
 - **Substrate failures:** PulseDB errors (connection, query) surface through Result types, excepting the best-effort paths above
 
 **What Must Never Fail Silently (intent; the best-effort exceptions above are the known gaps):**

--- a/docs/adr/007-failure-visibility.md
+++ b/docs/adr/007-failure-visibility.md
@@ -13,7 +13,14 @@ PulseHive operates in complex distributed systems (LLM providers, substrate) whe
 
 **Failure Visibility:**
 - **Result types:** Public APIs return `Result<T, E>` for fallible operations
-- **No silent failures, with documented best-effort exceptions:** Most failures surface through `Result`, but known paths are best-effort today: `HiveMind::deploy` only logs a failed Watch subscription; `record_experience` logs and continues after an embedding failure, silently ignores `get_experience` errors, and logs-and-continues after `store_relation` and `store_insight` failures; and the event stream drops events with a warning when a subscriber lags (`pulsehive-runtime/src/hivemind.rs`); error propagation for these paths is tracked in #57
+- **No silent failures, with documented best-effort exceptions:** Most failures surface through `Result`, but known paths are best-effort today — they log (or silently skip) and continue (`pulsehive-runtime/src/`); error propagation is tracked in #57:
+  - `HiveMind::deploy` logs a failed Watch subscription and continues (`hivemind.rs`)
+  - `record_experience` continues after an embedding failure, silently ignores `get_experience` errors, and logs-and-continues after `store_relation` and `store_insight` failures (`hivemind.rs`)
+  - the event stream drops events with a warning when a subscriber lags (`hivemind.rs`)
+  - the agentic loop continues with empty context when perception fails, stores experiences without embeddings after an embedding failure, and still returns the successful `AgentOutcome` when `store_experience` fails (`agentic_loop.rs`)
+  - the streaming-tool progress forwarder is aborted with a warning after the drain grace period when a tool leaves its progress sender open (`agentic_loop.rs`)
+  - relationship detection and insight synthesis log and continue when their substrate queries (`search_similar`, `get_related`) or insight LLM calls fail (`intelligence/`)
+- **Known panic path:** the built-in provider constructors panic via `.expect` if reqwest client construction fails instead of returning `Result` (tracked in #61)
 - **Documented error conditions:** All error variants documented in API docs
 - **Provider failures:** LLM provider errors propagate to consumer
 - **Substrate failures:** PulseDB errors (connection, query) surface through Result types, excepting the best-effort paths above
@@ -39,5 +46,5 @@ PulseHive operates in complex distributed systems (LLM providers, substrate) whe
 - Some operations become fallible that could be infallible in theory
 
 **Negative:**
-- The best-effort paths above (Watch subscription, embedding, `get_experience`, `store_relation`, `store_insight`, lagged event delivery) are currently log-only or silent (propagation tracked in #57)
+- The best-effort sites above are log-only or silent today (propagation tracked in #57), and provider constructors panic on client-build failure (Result return tracked in #61)
 - Error propagation requires careful consumer design

--- a/docs/adr/007-failure-visibility.md
+++ b/docs/adr/007-failure-visibility.md
@@ -13,12 +13,12 @@ PulseHive operates in complex distributed systems (LLM providers, substrate) whe
 
 **Failure Visibility:**
 - **Result types:** Public APIs return `Result<T, E>` for fallible operations
-- **No silent failures:** Library never suppresses errors without explicit consumer acknowledgement
+- **No silent failures, with documented best-effort exceptions:** Most failures surface through `Result`, but known paths are best-effort today: `HiveMind::deploy` only logs a failed Watch subscription, and `record_experience` logs and continues after an embedding failure and silently ignores `get_experience` errors (`pulsehive-runtime/src/hivemind.rs`); error propagation for these paths is tracked in #57
 - **Documented error conditions:** All error variants documented in API docs
 - **Provider failures:** LLM provider errors propagate to consumer
-- **Substrate failures:** PulseDB errors (connection, query) surface through Result types
+- **Substrate failures:** PulseDB errors (connection, query) surface through Result types, excepting the best-effort paths above
 
-**What Must Never Fail Silently:**
+**What Must Never Fail Silently (intent; the best-effort exceptions above are the known gaps):**
 - API key authentication failures
 - Substrate connection failures
 - LLM provider outages
@@ -32,12 +32,12 @@ PulseHive operates in complex distributed systems (LLM providers, substrate) whe
 **Positive:**
 - Consumers can implement targeted error handling
 - Failures are debuggable and observable
-- No hidden error suppression
+- Best-effort exception paths are documented rather than hidden (propagation tracked in #57)
 
 **Neutral:**
 - Error handling boilerplate required in consumer code
 - Some operations become fallible that could be infallible in theory
 
 **Negative:**
-- Cannot suppress transient errors without consumer awareness
+- Deploy-time Watch subscription and record_experience embedding/get_experience failures are currently log-only or silent (propagation tracked in #57)
 - Error propagation requires careful consumer design

--- a/docs/adr/007-failure-visibility.md
+++ b/docs/adr/007-failure-visibility.md
@@ -13,7 +13,7 @@ PulseHive operates in complex distributed systems (LLM providers, substrate) whe
 
 **Failure Visibility:**
 - **Result types:** Public APIs return `Result<T, E>` for fallible operations
-- **No silent failures, with documented best-effort exceptions:** Most failures surface through `Result`, but known paths are best-effort today: `HiveMind::deploy` only logs a failed Watch subscription, and `record_experience` logs and continues after an embedding failure and silently ignores `get_experience` errors (`pulsehive-runtime/src/hivemind.rs`); error propagation for these paths is tracked in #57
+- **No silent failures, with documented best-effort exceptions:** Most failures surface through `Result`, but known paths are best-effort today: `HiveMind::deploy` only logs a failed Watch subscription; `record_experience` logs and continues after an embedding failure, silently ignores `get_experience` errors, and logs-and-continues after `store_relation` and `store_insight` failures; and the event stream drops events with a warning when a subscriber lags (`pulsehive-runtime/src/hivemind.rs`); error propagation for these paths is tracked in #57
 - **Documented error conditions:** All error variants documented in API docs
 - **Provider failures:** LLM provider errors propagate to consumer
 - **Substrate failures:** PulseDB errors (connection, query) surface through Result types, excepting the best-effort paths above
@@ -39,5 +39,5 @@ PulseHive operates in complex distributed systems (LLM providers, substrate) whe
 - Some operations become fallible that could be infallible in theory
 
 **Negative:**
-- Deploy-time Watch subscription and record_experience embedding/get_experience failures are currently log-only or silent (propagation tracked in #57)
+- The best-effort paths above (Watch subscription, embedding, `get_experience`, `store_relation`, `store_insight`, lagged event delivery) are currently log-only or silent (propagation tracked in #57)
 - Error propagation requires careful consumer design

--- a/docs/adr/008-rollback.md
+++ b/docs/adr/008-rollback.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted
 **Category:** 7 - Rollback & evolution strategy
-**Touch Surface:** `Cargo.toml,CHANGELOG.md`
+**Touch Surface:** `Cargo.toml,pulsehive*/Cargo.toml,.github/workflows/crates-release.yml,CHANGELOG.md`
 **Revisit Trigger:** When introducing breaking migration
 
 ## Context

--- a/docs/adr/008-rollback.md
+++ b/docs/adr/008-rollback.md
@@ -1,0 +1,45 @@
+# ADR 008: Rollback & Evolution Strategy
+
+**Status:** Accepted
+**Category:** 7 - Rollback & evolution strategy
+**Touch Surface:** `Cargo.toml,CHANGELOG.md`
+**Revisit Trigger:** When introducing breaking migration
+
+## Context
+
+PulseHive is published to crates.io as versioned releases with multiple downstream consumers.
+
+## Decision
+
+**Rollback Strategy:**
+- **Crates.io versioned releases:** Each version is permanently published
+- **Semantic versioning:** MAJOR.MINOR.PATCH indicates breaking/feature/fix level
+- **Rollback mechanism:** Consumers downgrade to previous published version
+- **Deprecation policy:** Deprecated features persist for one major version cycle
+
+**Evolution Strategy:**
+- **Additive changes preferred:** New features added without breaking existing code
+- **Breaking changes:** Batched into major version releases with migration guide
+- **Compatibility shims:** Temporary adapters for major transitions (e.g., v2→v3)
+- **CHANGELOG.md:** Document all changes per release
+
+**Load-bearing vs Replaceable:**
+- **Load-bearing:** Five primitives, PulseDB boundary, AGPL-3.0 licensing (deliberately fixed)
+- **Replaceable:** Provider implementations, tool implementations, specific algorithms
+
+**Rationale:** Semantic versioning provides clear rollback signals. Permanent publication enables downgrades. Additive evolution respects consumer upgrade cycles.
+
+## Consequences
+
+**Positive:**
+- Consumers can rollback by downgrading crates.io version
+- Clear upgrade paths via semantic versioning
+- Deprecation enables graceful migration
+
+**Neutral:**
+- Breaking changes require major version bump
+- Consumers must actively upgrade to receive fixes
+
+**Negative:**
+- Cannot remove deprecated features quickly
+- Breaking changes require coordinated migration across ecosystem

--- a/docs/adr/008-rollback.md
+++ b/docs/adr/008-rollback.md
@@ -14,7 +14,7 @@ PulseHive is published to crates.io as versioned releases with multiple downstre
 **Rollback Strategy:**
 - **Crates.io versioned releases:** Each version is permanently published
 - **Semantic versioning:** MAJOR.MINOR.PATCH indicates breaking/feature/fix level
-- **Rollback mechanism:** Consumers downgrade to previous published version
+- **Rollback mechanism:** Consumers downgrade to the previous published version. The rollback release unit is the coordinated set of seven crates published together (`pulsehive`, `pulsehive-core`, `pulsehive-runtime`, `pulsehive-openai`, `pulsehive-anthropic`, `pulsehive-py`, `pulsehive-js`); a rollback must use exact matching version constraints (e.g. `=x.y.z`) across the set, and consumers must rely on their own `Cargo.lock` for reproducible resolution. Rollback for the PyPI and npm bindings is not specified here (tracked in #59)
 - **Deprecation policy:** Deprecated features persist for one major version cycle
 
 **Evolution Strategy:**
@@ -24,7 +24,7 @@ PulseHive is published to crates.io as versioned releases with multiple downstre
 - **CHANGELOG.md:** Document all changes per release
 
 **Load-bearing vs Replaceable:**
-- **Load-bearing:** Five primitives, PulseDB boundary, AGPL-3.0 licensing (deliberately fixed)
+- **Load-bearing:** Five primitives, PulseDB boundary, AGPL-3.0-only licensing (open-source option, commercial license available; deliberately fixed)
 - **Replaceable:** Provider implementations, tool implementations, specific algorithms
 
 **Rationale:** Semantic versioning provides clear rollback signals. Permanent publication enables downgrades. Additive evolution respects consumer upgrade cycles.

--- a/docs/adr/008-rollback.md
+++ b/docs/adr/008-rollback.md
@@ -14,7 +14,7 @@ PulseHive is published to crates.io as versioned releases with multiple downstre
 **Rollback Strategy:**
 - **Crates.io versioned releases:** Each version is permanently published
 - **Semantic versioning:** MAJOR.MINOR.PATCH indicates breaking/feature/fix level
-- **Rollback mechanism:** Consumers downgrade to the previous published version. The rollback release unit is the coordinated set of seven crates published together (`pulsehive`, `pulsehive-core`, `pulsehive-runtime`, `pulsehive-openai`, `pulsehive-anthropic`, `pulsehive-py`, `pulsehive-js`); a rollback must use exact matching version constraints (e.g. `=x.y.z`) across the set, and consumers must rely on their own `Cargo.lock` for reproducible resolution. Rollback for the PyPI and npm bindings is not specified here (tracked in #59)
+- **Rollback mechanism:** Consumers downgrade to the previous published version. The rollback release unit is the five crates jointly published to crates.io (`pulsehive`, `pulsehive-core`, `pulsehive-runtime`, `pulsehive-openai`, `pulsehive-anthropic`); a rollback must use exact matching version constraints (e.g. `=x.y.z`) across the five, and consumers must rely on their own `Cargo.lock` for reproducible resolution. The PyPI Python artifact (independently versioned, currently 0.3.0b2) and the npm `@pulsehive/sdk` package are separately versioned binding artifacts; their rollback is not specified here (tracked in #59)
 - **Deprecation policy:** Deprecated features persist for one major version cycle
 
 **Evolution Strategy:**

--- a/docs/adr/009-stack.md
+++ b/docs/adr/009-stack.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted
 **Category:** 8 - Stack
-**Touch Surface:** `Cargo.toml,pulsehive-core/src/lib.rs`
+**Touch Surface:** `Cargo.toml,pulsehive*/src/`
 **Revisit Trigger:** When requiring unsafe or changing runtime
 
 ## Context

--- a/docs/adr/009-stack.md
+++ b/docs/adr/009-stack.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted
 **Category:** 8 - Stack
-**Touch Surface:** `Cargo.toml,pulsehive*/src/`
+**Touch Surface:** `Cargo.toml,pulsehive*/src/,pulsehive-py/pyproject.toml,pulsehive-js/package.json`
 **Revisit Trigger:** When requiring unsafe or changing runtime
 
 ## Context

--- a/docs/adr/009-stack.md
+++ b/docs/adr/009-stack.md
@@ -1,0 +1,47 @@
+# ADR 009: Stack Choices
+
+**Status:** Accepted
+**Category:** 8 - Stack
+**Touch Surface:** `Cargo.toml,pulsehive-core/src/lib.rs`
+**Revisit Trigger:** When requiring unsafe or changing runtime
+
+## Context
+
+PulseHive is a Rust library with specific technology choices that enable its design goals.
+
+## Decision
+
+**Core Stack:**
+- **Language:** Rust (edition 2021)
+- **Runtime:** Tokio async runtime
+- **Key frameworks:** pulsehive-db 0.5, serde, tokio
+- **Storage:** PulseDB (HNSW vector search, knowledge graph, watch system)
+- **Build tooling:** Cargo, workspace structure
+- **Test tooling:** cargo test, cargo doc (doc-tests)
+
+**Code Quality Constraints:**
+- **`#![forbid(unsafe_code)]`:** No unsafe code in library crates
+- **Object-safe traits:** Core traits are `Send + Sync`, object-safe
+- **Async traits:** `async_trait` where needed for trait methods
+
+**Reversibility:**
+- **Reversible:** Dependency versions, specific crates, test frameworks
+- **Irreversible:** Rust language choice, Tokio runtime, forbid-unsafe constraint
+
+**Rationale:** Rust provides memory safety and performance. Tokio is the de facto async runtime. `forbid(unsafe_code)` ensures safety guarantees. Object-safe traits enable dynamic dispatch.
+
+## Consequences
+
+**Positive:**
+- Memory safety without garbage collector
+- Strong type system prevents entire classes of bugs
+- No unsafe code in library surface
+
+**Neutral:**
+- Async complexity required for LLM integration
+- Compilation times inherent to Rust
+
+**Negative:**
+- Cannot use unsafe optimizations even if beneficial
+- Tokio runtime dependency is hard to replace
+- FFI (PyO3, napi-rs) adds complexity

--- a/docs/adr/009-stack.md
+++ b/docs/adr/009-stack.md
@@ -20,22 +20,22 @@ PulseHive is a Rust library with specific technology choices that enable its des
 - **Test tooling:** cargo test, cargo doc (doc-tests)
 
 **Code Quality Constraints:**
-- **`#![forbid(unsafe_code)]`:** No unsafe code in library crates
+- **Unsafe-free library crates (intent):** Library crates are to stay free of `unsafe` code; `pulsehive-py`'s `unsafe impl Send`/`Sync` for its Python tool bridge is the known binding exception. No crate currently carries `#![forbid(unsafe_code)]`, so this is recorded as intent — lint enforcement is tracked in #55
 - **Object-safe traits:** Core traits are `Send + Sync`, object-safe
 - **Async traits:** `async_trait` where needed for trait methods
 
 **Reversibility:**
 - **Reversible:** Dependency versions, specific crates, test frameworks
-- **Irreversible:** Rust language choice, Tokio runtime, forbid-unsafe constraint
+- **Irreversible:** Rust language choice, Tokio runtime, unsafe-free constraint
 
-**Rationale:** Rust provides memory safety and performance. Tokio is the de facto async runtime. `forbid(unsafe_code)` ensures safety guarantees. Object-safe traits enable dynamic dispatch.
+**Rationale:** Rust provides memory safety and performance. Tokio is the de facto async runtime. The unsafe-free intent keeps safety guarantees in library code, with `pulsehive-py`'s Send/Sync impls as the accepted binding exception (enforcement tracked in #55). Object-safe traits enable dynamic dispatch.
 
 ## Consequences
 
 **Positive:**
 - Memory safety without garbage collector
 - Strong type system prevents entire classes of bugs
-- No unsafe code in library surface
+- Library crates stay unsafe-free by intent (binding exception: `pulsehive-py` Send/Sync; enforcement tracked in #55)
 
 **Neutral:**
 - Async complexity required for LLM integration

--- a/docs/adr/009-stack.md
+++ b/docs/adr/009-stack.md
@@ -17,7 +17,7 @@ PulseHive is a Rust library with specific technology choices that enable its des
 - **Key frameworks:** pulsehive-db 0.5, serde, tokio
 - **Storage:** PulseDB (HNSW vector search, knowledge graph, watch system)
 - **Build tooling:** Cargo, workspace structure
-- **Test tooling:** cargo test, cargo doc (doc-tests)
+- **Test tooling:** cargo test (including doc-tests), cargo doc (documentation checks)
 
 **Code Quality Constraints:**
 - **Unsafe-free library crates (intent):** Library crates are to stay free of `unsafe` code; `pulsehive-py`'s `unsafe impl Send`/`Sync` for its Python tool bridge is the known binding exception. No crate currently carries `#![forbid(unsafe_code)]`, so this is recorded as intent — lint enforcement is tracked in #55

--- a/docs/adr/010-cross-cutting.md
+++ b/docs/adr/010-cross-cutting.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted
 **Category:** 9 - Cross-cutting constraints
-**Touch Surface:** `pulsehive*/src/`
+**Touch Surface:** `Cargo.toml,LICENSE,LICENSING.md,pulsehive-py/pyproject.toml,pulsehive-js/package.json,pulsehive*/src/`
 **Revisit Trigger:** When considering sixth primitive or license change
 
 ## Context

--- a/docs/adr/010-cross-cutting.md
+++ b/docs/adr/010-cross-cutting.md
@@ -35,7 +35,8 @@ PulseHive has fundamental architectural constraints that apply across all module
 
 **Provider Abstraction:**
 - LLM access through `LlmProvider` trait only
-- No hardcoded provider implementations
+- No hardcoded provider selection or transport behavior in core
+- Provider crates may implement `LlmProvider` (e.g. `pulsehive-openai`)
 - Pluggable provider model
 
 **Rationale:** These constraints keep PulseHive small, composable, and maintainable. The five-primitive boundary prevents framework bloat. Object-safe traits enable dynamic composition. AGPL ensures open-source contributions remain open.

--- a/docs/adr/010-cross-cutting.md
+++ b/docs/adr/010-cross-cutting.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted
 **Category:** 9 - Cross-cutting constraints
-**Touch Surface:** `pulsehive-core/src/`
+**Touch Surface:** `pulsehive*/src/`
 **Revisit Trigger:** When considering sixth primitive or license change
 
 ## Context

--- a/docs/adr/010-cross-cutting.md
+++ b/docs/adr/010-cross-cutting.md
@@ -1,0 +1,59 @@
+# ADR 010: Cross-Cutting Constraints
+
+**Status:** Accepted
+**Category:** 9 - Cross-cutting constraints
+**Touch Surface:** `pulsehive-core/src/`
+**Revisit Trigger:** When considering sixth primitive or license change
+
+## Context
+
+PulseHive has fundamental architectural constraints that apply across all modules.
+
+## Decision
+
+**Cross-Cutting Constraints:**
+
+**Five Primitives Hard Cap:**
+- Exactly five primitives: HiveMind, Agent, Tool, Lens, Experience
+- No sixth primitive without demonstrated use case
+- Enforced via architecture review and code review
+
+**Object-Safe Traits:**
+- Core traits are `Send + Sync`, object-safe (`Arc<dyn Trait>`)
+- Enables dynamic dispatch and trait objects
+- `as_*() -> Option<&dyn Ext>` pattern for capability extensions
+
+**Licensing:**
+- AGPL-3.0-only (open-source license in source)
+- Commercial license option available
+- Dual licensing model enforced
+
+**Substrate Boundary:**
+- PulseDB strict separation enforced
+- PulseHive cannot implement storage primitives
+- All storage goes through substrate abstraction
+
+**Provider Abstraction:**
+- LLM access through `LlmProvider` trait only
+- No hardcoded provider implementations
+- Pluggable provider model
+
+**Rationale:** These constraints keep PulseHive small, composable, and maintainable. The five-primitive boundary prevents framework bloat. Object-safe traits enable dynamic composition. AGPL ensures open-source contributions remain open.
+
+## Consequences
+
+**Positive:**
+- Framework remains small enough to reason about
+- Clear boundaries prevent scope creep
+- Provider abstraction enables multiple backends
+- AGPL protects open-source investments
+
+**Neutral:**
+- New primitive requires strong justification process
+- Object-safe trait requirements limit some API designs
+- AGPL may limit commercial adoption without commercial license
+
+**Negative:**
+- Cannot quickly add primitives for new use cases
+- AGPL incompatible with some proprietary integration requirements
+- Object-safe constraints prevent some generic patterns

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -11,9 +11,18 @@ ADRs follow numbered naming convention: `NNN-decision-title.md`
 | N | Date | Decision | Status |
 |---|------|----------|--------|
 | 001 | 2026-08-23 | Ossify Adoption | Accepted |
+| 002 | 2026-08-24 | System Shape & Deployment Topology | Accepted |
+| 003 | 2026-08-24 | Module Boundaries & Dependency Direction | Accepted |
+| 004 | 2026-08-24 | Data Ownership & Migration Posture | Accepted |
+| 005 | 2026-08-24 | Public Contracts & Compatibility Policy | Accepted |
+| 006 | 2026-08-24 | Trust Boundaries & Destructive Operations | Accepted |
+| 007 | 2026-08-24 | Failure Visibility | Accepted |
+| 008 | 2026-08-24 | Rollback & Evolution Strategy | Accepted |
+| 009 | 2026-08-24 | Stack Choices | Accepted |
+| 010 | 2026-08-24 | Cross-Cutting Constraints | Accepted |
 
 ---
 
 ## Series
 
-This ADR series begins with the ossify adoption on 2026-08-23. Prior architectural decisions are preserved in the AI workspace's `10-decisions-log.md`.
+This ADR series begins with the ossify adoption on 2026-08-23. ADRs 002–010 are the nine architectural bones back-derived from the adopted baseline and recorded on 2026-08-24.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,0 +1,19 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) for PulseHive.
+
+## Format
+
+ADRs follow numbered naming convention: `NNN-decision-title.md`
+
+## Index
+
+| N | Date | Decision | Status |
+|---|------|----------|--------|
+| 001 | 2026-08-23 | Ossify Adoption | Accepted |
+
+---
+
+## Series
+
+This ADR series begins with the ossify adoption on 2026-08-23. Prior architectural decisions are preserved in the AI workspace's `10-decisions-log.md`.


### PR DESCRIPTION
Docs-only. Adds the ADR series that the ossify adoption (2026-08-23) established: ADR-001 records the adoption itself and ADR-002 through ADR-010 record the nine architectural bones (system shape, module boundaries, data ownership, public contracts, trust boundaries, failure visibility, rollback, stack, cross-cutting constraints).

Landing this first keeps the upcoming Release 1 spine PRs (r1.s1 provider transport hardening and siblings) to their own changes; r1.s1 will add ADR-011 beside these.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GK7qeZvY6pjFRarzncBHsD
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pulseai-labs/pulsehive/pull/48" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added ten accepted architecture decision records covering system structure, module boundaries, data ownership, public contracts, trust boundaries, failure visibility, rollback, technology choices, and cross-cutting constraints.
  * Documented licensing, compatibility, migration, error-handling, security, deployment, resource-management, and provider-integration policies.
  * Added an architecture index describing the ADR series, formatting guidance, and baseline adoption record.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->